### PR TITLE
Implement find_all and find_by_handle

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ An SMBIOS Library created in Rust that reads (decodes) raw BIOS data
 ## Table of contents
 * [General info](#general-info)
 * [Dependencies](#dependencies)
-* [Example](#example)
+* [Security](#security)
+* [Examples](#examples)
 
 ## General info
 This project reads raw SMBIOS data from either a device or file.
@@ -14,6 +15,8 @@ This project reads raw SMBIOS data from either a device or file.
 Specification 3.4.0](https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.4.0.pdf)
 * Unix family
 * Windows family
+
+> SMBIOS 3.4.0 contains 46 defined structure types, all of which are covered by this library (types 0-43, 126, and 127).  Support via extensibility exists for types 128-255 (reserved for OEMs).  Extensibility also applies in the case when this library has not been updated for the latest specification version or a pre-released specification and a new type is introduced.
 
 ### Planned Support
 * MacOS
@@ -26,11 +29,18 @@ The current development stage is to finalize the API design.
 ## Dependencies
 * libc version: 0.2 (On Windows family only)
 	
-## Example
-Example code that retrieves the System UUID from a device (Windows or Linux family):
+## Security
+This library design follows a strict security mantra: *"Never trust the input"*.
+
+SMBIOS has been around for decades and has undergone many versions and revisions.  Many OEM vendors have interpreted and implemented the specifications over the years. Known cases of incorrect firmware implementations exist.  This presents a veritable labrynth of logic for both the known and the unknown. Rather than creating such a complex state machine, we take advantage of Rust's [Option<>](https://doc.rust-lang.org/std/option/) trait and assert that the act of retrival for any and all information may fail.  The burden of proof thus shifts from the library to the library consumer who is required to implement the failing condition arm.
+
+## Examples
+### Retrieve a Field of a Single Instance Structure - find_first()
+Some structures are required and a single instance. (e.g. [SMBiosSystemInformation](structs/types/system_information.rs))
 
 ```rust
 #[test]
+/// Retrieves the System UUID from a device
 fn retrieve_system_uuid() {
     match table_load_from_device() {
         Ok(data) => match data.find_first::<SMBiosSystemInformation>() {
@@ -49,5 +59,89 @@ Output:
 ```
 running 1 test
 System Information UUID == Uuid(4EE6523F-D56A-F3EA-8E2A-891CF96286EA)
-test windows_retrieve_system_uuid ... ok
-````
+test retrieve_system_uuid ... ok
+```
+
+### Retrieve Multiple Instances of a Structure - find_all()
+Some structures are allowed to have more than one instance. (e.g. [SMBiosMemoryDevice](structs/types/memory_device.rs))
+
+```rust
+#[test]
+/// Prints information for all memory devices within a device.
+fn print_all_memory_devices() {
+    match table_load_from_device() {
+        Ok(data) => {
+            for memory_device in data.find_all::<SMBiosMemoryDevice>() {
+                println!("{:#?}", memory_device);
+            }
+        }
+        Err(err) => println!("failure: {:?}", err),
+    }
+}
+```
+
+Output:
+```
+running 1 test
+smbioslib::structs::types::memory_device::SMBiosMemoryDevice {
+    header: smbioslib::core::header::Header {
+        struct_type: 17,
+        length: 40,
+        handle: smbioslib::structs::structure::Handle {
+            handle: 8,
+        },
+    },
+    physical_memory_array_handle: Some(
+        smbioslib::structs::structure::Handle {
+            handle: 1,
+        },
+    ),
+[...elided...]
+```
+
+### Retrieve a Structure Given a Handle - find_by_handle()
+Some structures point to other structures via handles. (e.g. [SMBiosMemoryDevice](structs/types/memory_device.rs) points to [SMBiosPhysicalMemoryArray](structs/types/physical_memory_array.rs))
+
+```rust
+/// Finds an associated struct by handle
+#[test]
+fn struct_struct_association() {
+    match table_load_from_device() {
+        Ok(data) => match data.find_first::<SMBiosMemoryDevice>() {
+            Some(first_memory_device) => {
+                let handle = first_memory_device.physical_memory_array_handle().unwrap();
+                match data.find_by_handle(&handle) {
+                    Some(undefined_struct) => {
+                        let physical_memory_array = undefined_struct.defined_struct();
+                        println!("{:#?}", physical_memory_array)
+                    }
+                    None => println!("No Physical Memory Array (Type 16) structure found"),
+                }
+            }
+            None => println!("No Memory Device (Type 17) structure found"),
+        },
+        Err(err) => println!("failure: {:?}", err),
+    }
+}
+```
+
+Output:
+```
+running 1 test
+PhysicalMemoryArray(
+    smbioslib::structs::types::physical_memory_array::SMBiosPhysicalMemoryArray {
+        header: smbioslib::core::header::Header {
+            struct_type: 16,
+            length: 23,
+            handle: smbioslib::structs::structure::Handle {
+                handle: 1,
+            },
+        },
+        location: Some(
+            smbioslib::structs::types::physical_memory_array::MemoryArrayLocationData {
+                raw: 3,
+                value: SystemBoardOrMotherboard,
+            },
+        ),
+[...elided...]
+```

--- a/src/core/smbios_data.rs
+++ b/src/core/smbios_data.rs
@@ -37,7 +37,7 @@ impl SMBiosData {
         Ok(result)
     }
 
-    /// Iterator of the contained [UndefinedStruct] items.
+    /// Iterator of the contained [UndefinedStruct] items
     pub fn iter(&self) -> Iter<'_, UndefinedStruct> {
         self.table.iter()
     }
@@ -48,6 +48,19 @@ impl SMBiosData {
         T: SMBiosStruct<'a>,
     {
         self.table.find_first()
+    }
+
+    /// Finds the structure matching the given handle
+    pub fn find_by_handle<'a>(&'a self, handle: &Handle) -> Option<&UndefinedStruct> {
+        self.table.find_by_handle(handle)
+    }
+
+    /// Finds all occurances of the structure
+    pub fn find_all<'a, T>(&'a self) -> Vec<T>
+    where
+        T: SMBiosStruct<'a>,
+    {
+        self.table.find_all()
     }
 }
 

--- a/src/core/undefined_struct.rs
+++ b/src/core/undefined_struct.rs
@@ -191,6 +191,29 @@ impl<'a> UndefinedStructTable {
             .find(|smbios_struct| smbios_struct.header.struct_type() == T::STRUCT_TYPE)
             .and_then(|undefined_struct| Some(T::new(&undefined_struct)))
     }
+
+    /// Finds the structure matching the given handle
+    pub fn find_by_handle(&'a self, handle: &Handle) -> Option<&'a UndefinedStruct> {
+        self.iter()
+            .find(|smbios_struct| smbios_struct.header.handle() == *handle)
+            .and_then(|undefined_struct| Some(undefined_struct))
+    }
+
+    /// Finds all occurances of the structure
+    pub fn find_all<T>(&'a self) -> Vec<T>
+    where
+        T: SMBiosStruct<'a>,
+    {
+        self.iter()
+            .filter_map(|smbios_struct| {
+                if smbios_struct.header.struct_type() == T::STRUCT_TYPE {
+                    Some(T::new(smbios_struct))
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
 }
 
 impl From<Vec<u8>> for UndefinedStructTable {

--- a/src/structs/structure.rs
+++ b/src/structs/structure.rs
@@ -22,6 +22,7 @@ pub trait SMBiosStruct<'a> {
 /// Some structures will reference other structures by using this value.
 ///
 /// Dereference a handle (*handle) to access its u16 value.
+#[derive(PartialEq, Eq)]
 pub struct Handle(pub u16);
 
 impl Handle {

--- a/src/structs/types/memory_device.rs
+++ b/src/structs/types/memory_device.rs
@@ -26,8 +26,8 @@ impl<'a> SMBiosStruct<'a> for SMBiosMemoryDevice<'a> {
 impl<'a> SMBiosMemoryDevice<'a> {
     /// Handle, or instance number, associated with the
     /// [SMBiosPhysicalMemoryArray] to which this device belongs
-    pub fn physical_memory_array_handle(&self) -> Option<u16> {
-        self.parts.get_field_word(0x04)
+    pub fn physical_memory_array_handle(&self) -> Option<Handle> {
+        self.parts.get_field_handle(0x04)
     }
 
     /// Handle, or instance number, associated with any
@@ -38,8 +38,8 @@ impl<'a> SMBiosMemoryDevice<'a> {
     /// detected) or the handle of the error-information
     /// structure ([SMBiosMemoryErrorInformation32] or
     /// [SMBiosMemoryErrorInformation64]).
-    pub fn memory_error_information_handle(&self) -> Option<u16> {
-        self.parts.get_field_word(0x06)
+    pub fn memory_error_information_handle(&self) -> Option<Handle> {
+        self.parts.get_field_handle(0x06)
     }
 
     /// Total width, in bits, of this memory device, including

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -24,3 +24,36 @@ fn retrieve_system_uuid() {
         Err(err) => println!("failure: {:?}", err),
     }
 }
+
+#[test]
+fn print_all_memory_devices() {
+    match table_load_from_device() {
+        Ok(data) => {
+            for memory_device in data.find_all::<SMBiosMemoryDevice>() {
+                println!("{:#?}", memory_device);
+            }
+        }
+        Err(err) => println!("failure: {:?}", err),
+    }
+}
+
+/// Finds an associated struct by handle
+#[test]
+fn struct_struct_association() {
+    match table_load_from_device() {
+        Ok(data) => match data.find_first::<SMBiosMemoryDevice>() {
+            Some(first_memory_device) => {
+                let handle = first_memory_device.physical_memory_array_handle().unwrap();
+                match data.find_by_handle(&handle) {
+                    Some(undefined_struct) => {
+                        let physical_memory_array = undefined_struct.defined_struct();
+                        println!("{:#?}", physical_memory_array)
+                    }
+                    None => println!("No Physical Memory Array (Type 16) structure found"),
+                }
+            }
+            None => println!("No Memory Device (Type 17) structure found"),
+        },
+        Err(err) => println!("failure: {:?}", err),
+    }
+}


### PR DESCRIPTION
Added two primary user scenarios:
1. retrieving all structures of a given type
2. retrieving a structure pointed to by another structure (via handle)