### PR TITLE
juzuluag/macos rework smbios table

### DIFF
--- a/src/core/undefined_struct.rs
+++ b/src/core/undefined_struct.rs
@@ -258,6 +258,9 @@ impl From<Vec<u8>> for UndefinedStructTable {
             let mut a: bool;
             let mut b = true;
             loop {
+                if next_index >= len {
+                    break;
+                }
                 a = data[next_index] != 0;
                 next_index = next_index + 1;
                 if a || b {


### PR DESCRIPTION
Rework how to populate macOS smbios table. 
After running with these changes, this is the output:
```sh
                        "Integrated Video Controller",
                    ),
                    device_type: Some(
                        smbioslib::structs::types::on_board_device_information::OnBoardDevice {
                            raw: 131,
                            type_of_device: Video,
                            status: Enabled,
                        },
                    ),
                    device_type_instance: Some(
                        1,
                    ),
                    segment_group_number: Some(
                        SingleSegment,
                    ),
                    bus_number: Some(
                        Number(
                            0,
                        ),
                    ),
                    device_function_number: Some(
                        Number {
                            device: 0,
                            function: 0,
                        },
                    ),
                },
            ),
            OnboardDevicesExtendedInformation(
                smbioslib::structs::types::onboard_devices_extended_information::SMBiosOnboardDevicesExtendedInformation {
                    header: smbioslib::core::header::Header {
                        struct_type: 41,
                        length: 11,
                        handle: smbioslib::structs::structure::Handle {
                            handle: 16,
                        },
                    },
                    reference_designation: Some(
                        "Azalia Audio Codec",
                    ),
                    device_type: Some(
                        smbioslib::structs::types::on_board_device_information::OnBoardDevice {
                            raw: 135,
                            type_of_device: Sound,
                            status: Enabled,
                        },
                    ),
                    device_type_instance: Some(
                        1,
                    ),
                    segment_group_number: Some(
                        SingleSegment,
                    ),
                    bus_number: Some(
                        Number(
                            0,
                        ),
                    ),
                    device_function_number: Some(
                        Number {
                            device: 0,
                            function: 0,
                        },
                    ),
                },
            ),
            OnboardDevicesExtendedInformation(
                smbioslib::structs::types::onboard_devices_extended_information::SMBiosOnboardDevicesExtendedInformation {
                    header: smbioslib::core::header::Header {
                        struct_type: 41,
                        length: 11,
                        handle: smbioslib::structs::structure::Handle {
                            handle: 17,
                        },
                    },
                    reference_designation: Some(
                        "SATA",
                    ),
                    device_type: Some(
                        smbioslib::structs::types::on_board_device_information::OnBoardDevice {
                            raw: 137,
                            type_of_device: SataController,
                            status: Enabled,
                        },
                    ),
                    device_type_instance: Some(
                        1,
                    ),
                    segment_group_number: Some(
                        SingleSegment,
                    ),
                    bus_number: Some(
                        Number(
                            0,
                        ),
                    ),
                    device_function_number: Some(
                        Number {
                            device: 0,
                            function: 0,
                        },
                    ),
                },
            ),
            LanguageInformation(
                smbioslib::structs::types::bios_language_information::SMBiosBiosLanguageInformation {
                    header: smbioslib::core::header::Header {
                        struct_type: 13,
                        length: 22,
                        handle: smbioslib::structs::structure::Handle {
                            handle: 18,
                        },
                    },
                    number_of_installable_languages: Some(
                        1,
                    ),
                    flags: Some(
                        smbioslib::structs::types::bios_language_information::BiosLanguageFlags {
                            raw: 1,
                            language_format: Abbreviated,
                        },
                    ),
                    current_language: Some(
                        "en",
                    ),
                    installable_languages: [
                        "en",
                    ],
                },
            ),
            PortableBattery(
                smbioslib::structs::types::portable_battery::SMBiosPortableBattery {
                    header: smbioslib::core::header::Header {
                        struct_type: 22,
                        length: 26,
                        handle: smbioslib::structs::structure::Handle {
                            handle: 19,
                        },
                    },
                    location: None,
                    manufacturer: None,
                    manufacture_date: None,
                    serial_number: None,
                    device_name: None,
                    device_chemistry: Some(
                        smbioslib::structs::types::portable_battery::PortableBatteryDeviceChemistryData {
                            raw: 2,
                            value: Unknown,
                        },
                    ),
                    design_capacity: Some(
                        Unknown,
                    ),
                    design_voltage: Some(
                        Unknown,
                    ),
                    sbds_version_number: None,
                    maximum_error_in_battery_data: Some(
                        0,
                    ),
                    sbds_serial_number: Some(
                        0,
                    ),
                    sbds_manufacture_date: Some(
                        0,
                    ),
                    sbds_device_chemistry: None,
                    design_capacity_multiplier: Some(
                        0,
                    ),
                    oem_specific: Some(
                        0,
                    ),
                },
            ),
            SystemBootInformation(
                smbioslib::structs::types::system_boot_information::SMBiosSystemBootInformation {
                    header: smbioslib::core::header::Header {
                        struct_type: 32,
                        length: 11,
                        handle: smbioslib::structs::structure::Handle {
                            handle: 20,
                        },
                    },
                    boot_status_data: Some(
                        smbioslib::structs::types::system_boot_information::SMBiosSystemBootInformation {
                            system_boot_status: NoErrors,
                        },
                    ),
                },
            ),
            Undefined(
                smbioslib::structs::types::unknown::SMBiosUnknown {
                    header: smbioslib::core::header::Header {
                        struct_type: 131,
                        length: 6,
                        handle: smbioslib::structs::structure::Handle {
                            handle: 21,
                        },
                    },
                    fields: [
                        9,
                        16,
                    ],
                    strings: [],
                },
            ),
            Undefined(
                smbioslib::structs::types::unknown::SMBiosUnknown {
                    header: smbioslib::core::header::Header {
                        struct_type: 133,
                        length: 12,
                        handle: smbioslib::structs::structure::Handle {
                            handle: 22,
                        },
                    },
                    fields: [
                        50,
                        0,
                        0,
                        0,
                        0,
                        0,
                        0,
                        0,
                    ],
                    strings: [],
                },
            ),
            Undefined(
                smbioslib::structs::types::unknown::SMBiosUnknown {
                    header: smbioslib::core::header::Header {
                        struct_type: 128,
                        length: 96,
                        handle: smbioslib::structs::structure::Handle {
                            handle: 23,
                        },
                    },
                    fields: [
                        2,
                        0,
                        0,
                        0,
                        102,
                        240,
                        175,
                        255,
                        127,
                        255,
                        255,
                        255,
                        2,
                        0,
                        0,
                        0,
                        0,
                        0,
                        0,
                        0,
                        0,
                        176,
                        152,
                        255,
                        255,
                        207,
                        183,
                        255,
                        0,
                        208,
                        183,
                        255,
                        255,
                        63,
                        230,
                        255,
                        0,
                        0,
                        0,
                        0,
                        0,
                        0,
                        0,
                        0,
                        0,
                        0,
                        0,
                        0,
                        0,
                        0,
                        0,
                        0,
                        0,
                        0,
                        0,
                        0,
                        0,
                        0,
                        0,
                        0,
                        0,
                        0,
                        0,
                        0,
                        0,
                        0,
                        0,
                        0,
                        0,
                        0,
                        0,
                        0,
                        0,
                        0,
                        0,
                        0,
                        0,
                        0,
                        0,
                        0,
                        0,
                        0,
                        0,
                        0,
                        3,
                        0,
                        0,
                        0,
                        3,
                        0,
                        0,
                        0,
                    ],
                    strings: [],
                },
            ),
            Undefined(
                smbioslib::structs::types::unknown::SMBiosUnknown {
                    header: smbioslib::core::header::Header {
                        struct_type: 221,
                        length: 26,
                        handle: smbioslib::structs::structure::Handle {
                            handle: 24,
                        },
                    },
                    fields: [
                        3,
                        1,
                        0,
                        7,
                        0,
                        80,
                        64,
                        0,
                        2,
                        0,
                        0,
                        0,
                        0,
                        222,
                        0,
                        3,
                        0,
                        255,
                        255,
                        255,
                        255,
                        255,
                    ],
                    strings: [
                        "Reference Code - CPU",
                        "uCode Version",
                        "TXT ACM version",
                    ],
                },
            ),
            Undefined(
                smbioslib::structs::types::unknown::SMBiosUnknown {
                    header: smbioslib::core::header::Header {
                        struct_type: 221,
                        length: 26,
                        handle: smbioslib::structs::structure::Handle {
                            handle: 25,
                        },
                    },
                    fields: [
                        3,
                        1,
                        0,
                        7,
                        0,
                        80,
                        64,
                        0,
                        2,
                        0,
                        0,
                        0,
                        0,
                        0,
                        0,
                        3,
                        4,
                        12,
                        0,
                        70,
                        116,
                        6,
                    ],
                    strings: [
                        "Reference Code - ME",
                        "MEBx version",
                        "ME Firmware Version",
                        "Consumer SKU",
                    ],
                },
            ),
            Undefined(
                smbioslib::structs::types::unknown::SMBiosUnknown {
                    header: smbioslib::core::header::Header {
                        struct_type: 221,
                        length: 82,
                        handle: smbioslib::structs::structure::Handle {
                            handle: 26,
                        },
                    },
                    fields: [
                        11,
                        1,
                        0,
                        7,
                        0,
                        80,
                        64,
                        0,
                        2,
                        3,
                        255,
                        255,
                        255,
                        255,
                        255,
                        4,
                        0,
                        255,
                        255,
                        255,
                        0,
                        0,
                        5,
                        0,
                        255,
                        255,
                        255,
                        0,
                        0,
                        6,
                        0,
                        255,
                        255,
                        255,
                        255,
                        255,
                        7,
                        0,
                        2,
                        0,
                        0,
                        0,
                        0,
                        8,
                        0,
                        9,
                        0,
                        0,
                        0,
                        0,
                        9,
                        0,
                        13,
                        0,
                        0,
                        0,
                        0,
                        10,
                        0,
                        7,
                        0,
                        0,
                        0,
                        0,
                        11,
                        0,
                        6,
                        0,
                        0,
                        0,
                        0,
                        12,
                        0,
                        8,
                        0,
                        0,
                        0,
                        0,
                    ],
                    strings: [
                        "Reference Code - CNL PCH",
                        "PCH-CRID Status",
                        "Disabled",
                        "PCH-CRID Original Value",
                        "PCH-CRID New Value",
                        "OPROM - RST - RAID",
                        "CNL PCH H A0 Hsio Version",
                        "CNL PCH H Ax Hsio Version",
                        "CNL PCH H Bx Hsio Version",
                        "CNL PCH LP B0 Hsio Version",
                        "CNL PCH LP Bx Hsio Version",
                        "CNL PCH LP Dx Hsio Version",
                    ],
                },
            ),
            Undefined(
                smbioslib::structs::types::unknown::SMBiosUnknown {
                    header: smbioslib::core::header::Header {
                        struct_type: 221,
                        length: 54,
                        handle: smbioslib::structs::structure::Handle {
                            handle: 27,
                        },
                    },
                    fields: [
                        7,
                        1,
                        0,
                        7,
                        0,
                        80,
                        64,
                        0,
                        2,
                        0,
                        0,
                        7,
                        1,
                        95,
                        0,
                        3,
                        0,
                        7,
                        0,
                        80,
                        64,
                        0,
                        4,
                        5,
                        255,
                        255,
                        255,
                        255,
                        255,
                        6,
                        0,
                        0,
                        0,
                        0,
                        13,
                        0,
                        7,
                        0,
                        0,
                        0,
                        0,
                        13,
                        0,
                        8,
                        0,
                        255,
                        255,
                        255,
                        255,
                        255,
                    ],
                    strings: [
                        "Reference Code - SA - System Agent",
                        "Reference Code - MRC",
                        "SA - PCIe Version",
                        "SA-CRID Status",
                        "Disabled",
                        "SA-CRID Original Value",
                        "SA-CRID New Value",
                        "OPROM - VBIOS",
                    ],
                },
            ),
            CacheInformation(
                smbioslib::structs::types::cache_information::SMBiosCacheInformation {
                    header: smbioslib::core::header::Header {
                        struct_type: 7,
                        length: 27,
                        handle: smbioslib::structs::structure::Handle {
                            handle: 28,
                        },
                    },
                    socket_designation: Some(
                        "L1 Cache",
                    ),
                    cache_configuration: Some(
                        smbioslib::structs::types::cache_information::CacheConfiguaration {
                            raw: 384,
                            cache_level: 1,
                            cache_socketed: false,
                            location: Internal,
                            enabled_at_boot: true,
                            operational_mode: WriteBack,
                        },
                    ),
                    maximum_cache_size: Some(
                        512,
                    ),
                    installed_size: Some(
                        512,
                    ),
                    supported_sram_type: Some(
                        smbioslib::structs::types::cache_information::SramTypes {
                            raw: 32,
                            other: false,
                            unknown: false,
                            non_burst: false,
                            burst: false,
                            pipeline_burst: false,
                            synchronous: true,
                            asynchronous: false,
                        },
                    ),
                    current_sram_type: Some(
                        smbioslib::structs::types::cache_information::SramTypes {
                            raw: 32,
                            other: false,
                            unknown: false,
                            non_burst: false,
                            burst: false,
                            pipeline_burst: false,
                            synchronous: true,
                            asynchronous: false,
                        },
                    ),
                    cache_speed: Some(
                        0,
                    ),
                    error_correction_type: Some(
                        smbioslib::structs::types::cache_information::ErrorCorrectionTypeData {
                            raw: 4,
                            value: Parity,
                        },
                    ),
                    system_cache_type: Some(
                        smbioslib::structs::types::cache_information::SystemCacheTypeData {
                            raw: 5,
                            value: Unified,
                        },
                    ),
                    associativity: Some(
                        smbioslib::structs::types::cache_information::CacheAssociativityData {
                            raw: 7,
                            value: SetAssociative8Way,
                        },
                    ),
                    maximum_cache_size_2: Some(
                        0,
                    ),
                    installed_cache_size_2: Some(
                        0,
                    ),
                },
            ),
            CacheInformation(
                smbioslib::structs::types::cache_information::SMBiosCacheInformation {
                    header: smbioslib::core::header::Header {
                        struct_type: 7,
                        length: 27,
                        handle: smbioslib::structs::structure::Handle {
                            handle: 29,
                        },
                    },
                    socket_designation: Some(
                        "L2 Cache",
                    ),
                    cache_configuration: Some(
                        smbioslib::structs::types::cache_information::CacheConfiguaration {
                            raw: 385,
                            cache_level: 2,
                            cache_socketed: false,
                            location: Internal,
                            enabled_at_boot: true,
                            operational_mode: WriteBack,
                        },
                    ),
                    maximum_cache_size: Some(
                        2048,
                    ),
                    installed_size: Some(
                        2048,
                    ),
                    supported_sram_type: Some(
                        smbioslib::structs::types::cache_information::SramTypes {
                            raw: 32,
                            other: false,
                            unknown: false,
                            non_burst: false,
                            burst: false,
                            pipeline_burst: false,
                            synchronous: true,
                            asynchronous: false,
                        },
                    ),
                    current_sram_type: Some(
                        smbioslib::structs::types::cache_information::SramTypes {
                            raw: 32,
                            other: false,
                            unknown: false,
                            non_burst: false,
                            burst: false,
                            pipeline_burst: false,
                            synchronous: true,
                            asynchronous: false,
                        },
                    ),
                    cache_speed: Some(
                        0,
                    ),
                    error_correction_type: Some(
                        smbioslib::structs::types::cache_information::ErrorCorrectionTypeData {
                            raw: 5,
                            value: SingleBitEcc,
                        },
                    ),
                    system_cache_type: Some(
                        smbioslib::structs::types::cache_information::SystemCacheTypeData {
                            raw: 5,
                            value: Unified,
                        },
                    ),
                    associativity: Some(
                        smbioslib::structs::types::cache_information::CacheAssociativityData {
                            raw: 5,
                            value: SetAssociative4Way,
                        },
                    ),
                    maximum_cache_size_2: Some(
                        0,
                    ),
                    installed_cache_size_2: Some(
                        0,
                    ),
                },
            ),
            CacheInformation(
                smbioslib::structs::types::cache_information::SMBiosCacheInformation {
                    header: smbioslib::core::header::Header {
                        struct_type: 7,
                        length: 27,
                        handle: smbioslib::structs::structure::Handle {
                            handle: 30,
                        },
                    },
                    socket_designation: Some(
                        "L3 Cache",
                    ),
                    cache_configuration: Some(
                        smbioslib::structs::types::cache_information::CacheConfiguaration {
                            raw: 386,
                            cache_level: 3,
                            cache_socketed: false,
                            location: Internal,
                            enabled_at_boot: true,
                            operational_mode: WriteBack,
                        },
                    ),
                    maximum_cache_size: Some(
                        16384,
                    ),
                    installed_size: Some(
                        16384,
                    ),
                    supported_sram_type: Some(
                        smbioslib::structs::types::cache_information::SramTypes {
                            raw: 32,
                            other: false,
                            unknown: false,
                            non_burst: false,
                            burst: false,
                            pipeline_burst: false,
                            synchronous: true,
                            asynchronous: false,
                        },
                    ),
                    current_sram_type: Some(
                        smbioslib::structs::types::cache_information::SramTypes {
                            raw: 32,
                            other: false,
                            unknown: false,
                            non_burst: false,
                            burst: false,
                            pipeline_burst: false,
                            synchronous: true,
                            asynchronous: false,
                        },
                    ),
                    cache_speed: Some(
                        0,
                    ),
                    error_correction_type: Some(
                        smbioslib::structs::types::cache_information::ErrorCorrectionTypeData {
                            raw: 6,
                            value: MultiBitEcc,
                        },
                    ),
                    system_cache_type: Some(
                        smbioslib::structs::types::cache_information::SystemCacheTypeData {
                            raw: 5,
                            value: Unified,
                        },
                    ),
                    associativity: Some(
                        smbioslib::structs::types::cache_information::CacheAssociativityData {
                            raw: 8,
                            value: SetAssociative16Way,
                        },
                    ),
                    maximum_cache_size_2: Some(
                        0,
                    ),
                    installed_cache_size_2: Some(
                        0,
                    ),
                },
            ),
            ProcessorInformation(
                smbioslib::structs::types::processor_information::SMBiosProcessorInformation {
                    header: smbioslib::core::header::Header {
                        struct_type: 4,
                        length: 48,
                        handle: smbioslib::structs::structure::Handle {
                            handle: 31,
                        },
                    },
                    socket_designation: Some(
                        "U3E1",
                    ),
                    processor_type: Some(
                        smbioslib::structs::types::processor_information::ProcessorTypeData {
                            raw: 3,
                            value: CentralProcessor,
                        },
                    ),
                    processor_family: Some(
                        smbioslib::structs::types::processor_information::ProcessorFamilyData {
                            raw: 207,
                            value: IntelCorei9processor,
                        },
                    ),
                    processor_manufacturer: Some(
                        "Intel(R) Corporation",
                    ),
                    processor_id: Some(
                        [
                            237,
                            6,
                            9,
                            0,
                            255,
                            251,
                            235,
                            191,
                        ],
                    ),
                    processor_version: Some(
                        "Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz",
                    ),
                    voltage: Some(
                        CurrentVolts(
                            0.8,
                        ),
                    ),
                    external_clock: Some(
                        MHz(
                            100,
                        ),
                    ),
                    max_speed: Some(
                        MHz(
                            2400,
                        ),
                    ),
                    current_speed: Some(
                        MHz(
                            2376,
                        ),
                    ),
                    status: Some(
                        smbioslib::structs::types::processor_information::ProcessorStatus {
                            raw: 65,
                            socket_populated: true,
                            cpu_status: Enabled,
                        },
                    ),
                    processor_upgrade: Some(
                        smbioslib::structs::types::processor_information::ProcessorUpgradeData {
                            raw: 1,
                            value: Other,
                        },
                    ),
                    l1cache_handle: Some(
                        smbioslib::structs::structure::Handle {
                            handle: 28,
                        },
                    ),
                    l2cache_handle: Some(
                        smbioslib::structs::structure::Handle {
                            handle: 29,
                        },
                    ),
                    l3cache_handle: Some(
                        smbioslib::structs::structure::Handle {
                            handle: 30,
                        },
                    ),
                    serial_number: Some(
                        "To Be Filled By O.E.M.",
                    ),
                    asset_tag: Some(
                        "To Be Filled By O.E.M.",
                    ),
                    part_number: Some(
                        "To Be Filled By O.E.M.",
                    ),
                    core_count: Some(
                        Count(
                            8,
                        ),
                    ),
                    cores_enabled: Some(
                        Count(
                            8,
                        ),
                    ),
                    thread_count: Some(
                        Count(
                            16,
                        ),
                    ),
                    processor_characteristics: Some(
                        smbioslib::structs::types::processor_information::ProcessorCharacteristics {
                            raw: 252,
                            unknown: false,
                            bit_64capable: true,
                            multi_core: true,
                            hardware_thread: true,
                            execute_protection: true,
                            enhanced_virtualization: true,
                            power_performance_control: true,
                            bit_128capable: false,
                            arm_64soc_id: false,
                        },
                    ),
                    processor_family_2: Some(
                        smbioslib::structs::types::processor_information::ProcessorFamilyData2 {
                            raw: 207,
                            value: IntelCorei9processor,
                        },
                    ),
                    core_count_2: Some(
                        Count(
                            8,
                        ),
                    ),
                    cores_enabled_2: Some(
                        Count(
                            8,
                        ),
                    ),
                    thread_count_2: Some(
                        Count(
                            16,
                        ),
                    ),
                },
            ),
            GroupAssociations(
                smbioslib::structs::types::group_associations::SMBiosGroupAssociations {
                    header: smbioslib::core::header::Header {
                        struct_type: 14,
                        length: 8,
                        handle: smbioslib::structs::structure::Handle {
                            handle: 32,
                        },
                    },
                    group_name: Some(
                        "$MEI",
                    ),
                    number_of_items: Some(
                        1,
                    ),
                    item_iterator: [
                        smbioslib::structs::types::group_associations::GroupAssociationItem {
                            struct_type: Some(
                                219,
                            ),
                            item_handle: Some(
                                smbioslib::structs::structure::Handle {
                                    handle: 0,
                                },
                            ),
                        },
                    ],
                },
            ),
        ],
    ),
}

```