### PR TITLE
Reviewed and documented BIOS string implementation strategy

### DIFF
--- a/src/core/strings.rs
+++ b/src/core/strings.rs
@@ -31,7 +31,7 @@ impl Strings {
         self.current_string_index = 0;
     }
 
-    /// Returns a String at the given _index_
+    /// Returns a [String] at the given `index`
     pub fn get_string(&self, index: u8) -> Option<String> {
         let index_usize = index as usize;
 
@@ -40,7 +40,18 @@ impl Strings {
             return None;
         }
 
-        // TODO: "*x as char" is not ISO-8859-1.  This should be made ISO-8859-1.
+        // Create an ISO-8859-1 String.  Each `u8 as char` operation maps a u8
+        // value (0xNN) to a Unicode code point (0x00NN).
+        //
+        // SMBIOS specification does not state that a BIOS string is ISO-8859-1 or
+        // ASCII (or anything else).  The reason it is important to use ISO-8859-1
+        // is that every u8 value (0-255) is represented and mapped 1:1 with a Unicode
+        // value.  Therefore, it is possible to reverse the process, starting from a
+        // Rust String or str and produce the original u8 array of values.
+        //
+        // Presently there is no need to convert back to a u8 array. If there were,
+        // the Rust char functions len_utf8() and encode_utf8() can be used.  If len_utf8()
+        // == 2 then the original u8 can be arrived at by combining bits from the two bytes.
         Some(
             self.strings[index_usize - 1]
                 .iter()


### PR DESCRIPTION
It turns out that the current implementation appears to need no changes.  In general BIOS implementations should be using 7 bit characters (values 0-127).  In the case someone should put in an ambiguous value we will use the simplest strategy to preserve the value and that is using the first two Unicode blocks (00-7F and 80-FF) which is ISO-8859-1.

It's completely conceivable someone may use a copyright symbol (A9 -> U+00A9) or registered symbol (AE -> U+00AE) and these would come through correctly.  However, if someone has decided to encode say via UTF-8 a code point like Trademark U+2122 it will of course appear as a gibberish `!"`.  A slightly more perceivable scenario is if someone uses for example ISO-8859-2 for a Slovak character (or any other -X which collides ISO-8859-1).

The bottom line is that this library aspires to preserve the original values found in BIOS and if a consumer of this library has knowledge that a particular ISO-8859-1 character should be represented as something else, they will be able to do the work to re-map that character so long as they know this library represents ISO-8859-1 and nothing else.