### PR TITLE
Move handle to a more logical location and impl FromStr

### DIFF
--- a/src/core/header.rs
+++ b/src/core/header.rs
@@ -1,6 +1,57 @@
-use std::{convert::TryInto, fmt};
+use std::{convert::TryInto, fmt, ops::Deref, str::FromStr};
 
-use crate::Handle;
+/// # Structure Handle
+///
+/// Each SMBIOS structure has a handle or instance value associated with it.
+/// Some structures will reference other structures by using this value.
+///
+/// Dereference a handle (*handle) to access its u16 value.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Handle(pub u16);
+
+impl Handle {
+    /// Handle Size (2 bytes)
+    pub const SIZE: usize = 2usize;
+}
+
+impl Deref for Handle {
+    type Target = u16;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl FromStr for Handle {
+    type Err = std::num::ParseIntError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Handle(u16::from_str(s)?))
+    }
+}
+
+/// # SMBIOS Structure Type
+///
+/// Each SMBIOS structure has a type number associated with it.
+///
+/// Dereference a structure type (*struct_type) to access its u8 value.
+pub struct SMBiosType(pub u8);
+
+impl Deref for SMBiosType {
+    type Target = u8;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl fmt::Debug for SMBiosType {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.debug_struct(std::any::type_name::<SMBiosType>())
+            .field("type", &self.0)
+            .finish()
+    }
+}
 
 /// # SMBIOS Header
 ///

--- a/src/core/smbios_data.rs
+++ b/src/core/smbios_data.rs
@@ -1,5 +1,6 @@
+use super::header::Handle;
 use super::undefined_struct::{UndefinedStruct, UndefinedStructTable};
-use crate::{DefinedStructTable, Handle, SMBiosStruct};
+use crate::structs::{DefinedStructTable, SMBiosStruct};
 use std::io::Error;
 use std::{cmp::Ordering, slice::Iter};
 use std::{fmt, fs::read};

--- a/src/core/undefined_struct.rs
+++ b/src/core/undefined_struct.rs
@@ -1,6 +1,6 @@
-use super::header::Header;
+use super::header::{Handle, Header};
 use super::strings::Strings;
-use crate::structs::{DefinedStruct, Handle, SMBiosEndOfTable, SMBiosStruct};
+use crate::structs::{DefinedStruct, SMBiosEndOfTable, SMBiosStruct};
 use std::fmt;
 use std::{convert::TryInto, slice::Iter};
 

--- a/src/structs/structure.rs
+++ b/src/structs/structure.rs
@@ -1,5 +1,4 @@
 use crate::core::UndefinedStruct;
-use std::{fmt, ops::Deref};
 
 /// # SMBIOS Structure
 ///
@@ -15,57 +14,4 @@ pub trait SMBiosStruct<'a> {
 
     /// Contains the standard parts/sections of the implementing SMBIOS type.
     fn parts(&self) -> &'a UndefinedStruct;
-}
-
-/// # Structure Handle
-///
-/// Each SMBIOS structure has a handle or instance value associated with it.
-/// Some structures will reference other structures by using this value.
-///
-/// Dereference a handle (*handle) to access its u16 value.
-#[derive(PartialEq, Eq)]
-pub struct Handle(pub u16);
-
-impl Handle {
-    /// Handle Size (2 bytes)
-    pub const SIZE: usize = 2usize;
-}
-
-impl Deref for Handle {
-    type Target = u16;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl fmt::Debug for Handle {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<Handle>())
-            .field("handle", &self.0)
-            .finish()
-    }
-}
-
-/// # SMBIOS Structure Type
-///
-/// Each SMBIOS structure has a type number associated with it.
-///
-/// Dereference a structure type (*struct_type) to access its u8 value.
-pub struct SMBiosType(pub u8);
-
-impl Deref for SMBiosType {
-    type Target = u8;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl fmt::Debug for SMBiosType {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SMBiosType>())
-            .field("type", &self.0)
-            .finish()
-    }
 }

--- a/src/structs/types/additional_information.rs
+++ b/src/structs/types/additional_information.rs
@@ -1,4 +1,5 @@
-use crate::{Handle, SMBiosStruct, UndefinedStruct};
+use crate::core::{Handle, UndefinedStruct};
+use crate::structs::SMBiosStruct;
 use std::fmt;
 
 /// # Additional Information Entry contained within [SMBiosAdditionalInformation]

--- a/src/structs/types/baseboard_information.rs
+++ b/src/structs/types/baseboard_information.rs
@@ -1,4 +1,5 @@
-use crate::{Handle, SMBiosStruct, UndefinedStruct};
+use crate::core::{Handle, UndefinedStruct};
+use crate::SMBiosStruct;
 use std::fmt;
 use std::ops::Deref;
 

--- a/src/structs/types/cooling_device.rs
+++ b/src/structs/types/cooling_device.rs
@@ -1,4 +1,5 @@
-use crate::{Handle, SMBiosStruct, UndefinedStruct};
+use crate::core::{Handle, UndefinedStruct};
+use crate::SMBiosStruct;
 use std::fmt;
 
 /// # Cooling Device (Type 27)

--- a/src/structs/types/group_associations.rs
+++ b/src/structs/types/group_associations.rs
@@ -1,4 +1,5 @@
-use crate::{Handle, SMBiosStruct, UndefinedStruct};
+use crate::core::{Handle, UndefinedStruct};
+use crate::SMBiosStruct;
 use std::fmt;
 
 /// # Group Associations (Type 14)

--- a/src/structs/types/management_device_component.rs
+++ b/src/structs/types/management_device_component.rs
@@ -1,4 +1,5 @@
-use crate::{Handle, SMBiosStruct, UndefinedStruct};
+use crate::core::{Handle, UndefinedStruct};
+use crate::SMBiosStruct;
 use std::fmt;
 
 /// # Management Device Component (Type 35)

--- a/src/structs/types/memory_array_mapped_address.rs
+++ b/src/structs/types/memory_array_mapped_address.rs
@@ -1,4 +1,5 @@
-use crate::{Handle, SMBiosStruct, UndefinedStruct};
+use crate::core::{Handle, UndefinedStruct};
+use crate::SMBiosStruct;
 use std::fmt;
 
 /// # Memory Array Mapped Address (Type 19)

--- a/src/structs/types/memory_channel.rs
+++ b/src/structs/types/memory_channel.rs
@@ -1,4 +1,5 @@
-use crate::{Handle, SMBiosStruct, UndefinedStruct};
+use crate::core::{Handle, UndefinedStruct};
+use crate::SMBiosStruct;
 use std::fmt;
 use std::ops::Deref;
 

--- a/src/structs/types/memory_controller_information.rs
+++ b/src/structs/types/memory_controller_information.rs
@@ -1,4 +1,5 @@
-use crate::{Handle, SMBiosStruct, UndefinedStruct};
+use crate::core::{Handle, UndefinedStruct};
+use crate::SMBiosStruct;
 use std::fmt;
 use std::ops::Deref;
 

--- a/src/structs/types/memory_device.rs
+++ b/src/structs/types/memory_device.rs
@@ -1,4 +1,5 @@
-use crate::{Handle, SMBiosStruct, UndefinedStruct};
+use crate::core::{Handle, UndefinedStruct};
+use crate::SMBiosStruct;
 use std::fmt;
 use std::ops::Deref;
 

--- a/src/structs/types/memory_device_mapped_address.rs
+++ b/src/structs/types/memory_device_mapped_address.rs
@@ -1,4 +1,5 @@
-use crate::{Handle, SMBiosStruct, UndefinedStruct};
+use crate::core::{Handle, UndefinedStruct};
+use crate::SMBiosStruct;
 use std::fmt;
 
 /// # Memory Device Mapped Address (Type 20)

--- a/src/structs/types/processor_additional_information.rs
+++ b/src/structs/types/processor_additional_information.rs
@@ -1,4 +1,5 @@
-use crate::{Handle, SMBiosStruct, UndefinedStruct};
+use crate::core::{Handle, UndefinedStruct};
+use crate::SMBiosStruct;
 use std::fmt;
 use std::ops::Deref;
 

--- a/src/structs/types/processor_information.rs
+++ b/src/structs/types/processor_information.rs
@@ -1,4 +1,5 @@
-use crate::{Handle, SMBiosStruct, UndefinedStruct};
+use crate::core::{Handle, UndefinedStruct};
+use crate::SMBiosStruct;
 use std::convert::TryInto;
 use std::fmt;
 use std::ops::Deref;

--- a/src/structs/types/system_chassis_information.rs
+++ b/src/structs/types/system_chassis_information.rs
@@ -1,4 +1,5 @@
-use crate::{BoardTypeData, SMBiosStruct, SMBiosType, UndefinedStruct};
+use crate::core::UndefinedStruct;
+use crate::{BoardTypeData, SMBiosStruct, SMBiosType};
 use std::fmt;
 use std::ops::Deref;
 


### PR DESCRIPTION
For dmidecode it is useful to make Handle read from a string by implementing FromStr.  Also corrected debug output for Handle and moved it to a better location (core).