### PR TITLE
Ensure access to raw data of the structures

### DIFF
--- a/src/core/header.rs
+++ b/src/core/header.rs
@@ -72,7 +72,7 @@ impl fmt::Debug for Header {
     }
 }
 
-impl<'a> Header {
+impl Header {
     /// Total size of a Header (4)
     ///
     /// A header has a byte for the _struct_type_ at offset 0,
@@ -92,10 +92,6 @@ impl<'a> Header {
 
     /// Creates a new [Header] struct
     pub fn new(data: [u8; 4]) -> Self {
-        assert!(
-            data.len() == Self::SIZE,
-            "Header must be 4 bytes in length, 1 for struct_type, 1 for length, and 2 for handle."
-        );
         Header(data)
     }
 
@@ -118,10 +114,23 @@ impl<'a> Header {
                 .expect("u16 is 2 bytes"),
         ))
     }
+
+    /// Byte iterator of the header
+    pub fn iter(&self) -> std::slice::Iter<'_, u8> {
+        self.0.iter()
+    }
 }
 
 impl From<[u8; 4]> for Header {
     fn from(data: [u8; 4]) -> Self {
         Header(data)
+    }
+}
+
+impl Deref for Header {
+    type Target = [u8; 4];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }

--- a/src/core/strings.rs
+++ b/src/core/strings.rs
@@ -59,6 +59,11 @@ impl Strings {
                 .collect(),
         )
     }
+
+    /// Iterates the raw bytes of the strings. The terminating 0 is not included in each string.
+    pub fn iter(&self) -> std::slice::Iter<'_, Vec<u8>> {
+        self.strings.iter()
+    }
 }
 
 impl Iterator for Strings {
@@ -70,7 +75,7 @@ impl Iterator for Strings {
             return None;
         }
 
-        // TODO: "*x as char" is not ISO-8859-1.  This should be made ISO-8859-1.
+        // "*x as char" is ISO-8859-1.
         let result: String = self.strings[self.current_string_index]
             .iter()
             .map(|x| *x as char)


### PR DESCRIPTION
dmidecode for example usese the -u option to dump in this way:

```
Handle 0x0000, DMI type 0, 20 bytes
        Header and Data:
                00 14 00 00 01 02 00 F0 03 03 90 DA CB 7F 00 00
                00 00 34 01
        Strings:
                41 6D 65 72 69 63 61 6E 20 4D 65 67 61 74 72 65
                6E 64 73 20 49 6E 63 2E 00
                "American Megatrends Inc."
                30 39 30 30 30 38 20 00
                "090008 "
                31 32 2F 30 37 2F 32 30 31 38 00
                "12/07/2018"
```

This requires access to the raw bytes behind the structures.