### PR TITLE
Add /dev/mem reading methods

### DIFF
--- a/src/core/entry_point.rs
+++ b/src/core/entry_point.rs
@@ -237,7 +237,7 @@ impl<'a> SMBiosEntryPoint32 {
     }
 
     /// Load this structure by scanning a file within the given offsets,
-    /// looking for the [SMBiosEntryPoint32::ANCHOR] string.
+    /// looking for the [SMBiosEntryPoint32::SM_ANCHOR] string.
     pub fn try_scan_from_file<T: Iterator<Item = u64>>(
         file: &mut File,
         range: T,
@@ -496,7 +496,7 @@ impl<'a> SMBiosEntryPoint64 {
     }
 
     /// Load this structure by scanning a file within the given offsets,
-    /// looking for the [SMBiosEntryPoint64::ANCHOR] string.
+    /// looking for the [SMBiosEntryPoint64::SM3_ANCHOR] string.
     pub fn try_scan_from_file<T: Iterator<Item = u64>>(
         file: &mut File,
         range: T,

--- a/src/core/entry_point.rs
+++ b/src/core/entry_point.rs
@@ -1,5 +1,12 @@
 use std::{
-    convert::TryFrom, convert::TryInto, fmt, fs::{read, File}, io::{Error, ErrorKind, SeekFrom, prelude::*}, num::Wrapping, ops::RangeBounds, path::Path
+    convert::TryFrom,
+    convert::TryInto,
+    fmt,
+    fs::{read, File},
+    io::{prelude::*, Error, ErrorKind, SeekFrom},
+    num::Wrapping,
+    ops::RangeBounds,
+    path::Path,
 };
 
 /// # SMBIOS 2.1 (32 bit) Entry Point structure
@@ -231,7 +238,13 @@ impl<'a> SMBiosEntryPoint32 {
 
     /// Load this structure by scanning a file within the given offsets,
     /// looking for the [SMBiosEntryPoint32::ANCHOR] string.
-    pub fn try_scan_from_file<T: Iterator<Item = u64>>(file: &mut File, range: T) -> Result<Self, Error> where T: RangeBounds<u64>, {
+    pub fn try_scan_from_file<T: Iterator<Item = u64>>(
+        file: &mut File,
+        range: T,
+    ) -> Result<Self, Error>
+    where
+        T: RangeBounds<u64>,
+    {
         let mut anchor = [0; 4];
         for offset in range.step_by(0x10) {
             file.seek(SeekFrom::Start(offset))?;
@@ -248,10 +261,7 @@ impl<'a> SMBiosEntryPoint32 {
                 return Ok(entry_point);
             }
         }
-        Err(Error::new(
-                ErrorKind::UnexpectedEof,
-                "Not found",
-            ))
+        Err(Error::new(ErrorKind::UnexpectedEof, "Not found"))
     }
 }
 
@@ -487,7 +497,13 @@ impl<'a> SMBiosEntryPoint64 {
 
     /// Load this structure by scanning a file within the given offsets,
     /// looking for the [SMBiosEntryPoint64::ANCHOR] string.
-    pub fn try_scan_from_file<T: Iterator<Item = u64>>(file: &mut File, range: T) -> Result<Self, Error> where T: RangeBounds<u64>, {
+    pub fn try_scan_from_file<T: Iterator<Item = u64>>(
+        file: &mut File,
+        range: T,
+    ) -> Result<Self, Error>
+    where
+        T: RangeBounds<u64>,
+    {
         let mut anchor = [0; 5];
         for offset in range.step_by(0x10) {
             file.seek(SeekFrom::Start(offset))?;
@@ -504,10 +520,7 @@ impl<'a> SMBiosEntryPoint64 {
                 return Ok(entry_point);
             }
         }
-        Err(Error::new(
-                ErrorKind::UnexpectedEof,
-                "Not found",
-            ))
+        Err(Error::new(ErrorKind::UnexpectedEof, "Not found"))
     }
 }
 

--- a/src/core/entry_point.rs
+++ b/src/core/entry_point.rs
@@ -72,7 +72,7 @@ impl<'a> SMBiosEntryPoint32 {
     pub const NUMBER_OF_SMBIOS_STRUCTURES_OFFSET: usize = 0x1C;
 
     /// SMBIOS BCD Revision Offset
-    pub const BCD_REVISION: usize = 0x1E;
+    pub const BCD_REVISION_OFFSET: usize = 0x1E;
 
     /// Entry Point Structure Checksum
     ///
@@ -221,7 +221,7 @@ impl<'a> SMBiosEntryPoint32 {
     /// Minor Versions in offsets 6 and 7 of the Entry Point Structure
     /// provide the version information.
     pub fn bcd_revision(&self) -> u8 {
-        self.raw[Self::BCD_REVISION]
+        self.raw[Self::BCD_REVISION_OFFSET]
     }
 
     /// Load this structure from a file
@@ -237,7 +237,6 @@ impl<'a> SMBiosEntryPoint32 {
             file.seek(SeekFrom::Start(offset))?;
             file.read_exact(&mut anchor)?;
             if anchor == Self::SM_ANCHOR {
-                println!("SMBiosEntryPoint32 offset: {:#X}", offset);
                 let mut length = [0; 2];
                 file.read_exact(&mut length)?;
                 let struct_length = length[1] as usize;
@@ -484,6 +483,31 @@ impl<'a> SMBiosEntryPoint64 {
     /// Load this structure from a file
     pub fn try_load_from_file(filename: &Path) -> Result<Self, Error> {
         read(filename)?.try_into()
+    }
+
+    /// Load this structure by scanning a file within the given offsets,
+    /// looking for the [SMBiosEntryPoint64::ANCHOR] string.
+    pub fn try_scan_from_file<T: Iterator<Item = u64>>(file: &mut File, range: T) -> Result<Self, Error> where T: RangeBounds<u64>, {
+        let mut anchor = [0; 5];
+        for offset in range.step_by(0x10) {
+            file.seek(SeekFrom::Start(offset))?;
+            file.read_exact(&mut anchor)?;
+            if anchor == Self::SM3_ANCHOR {
+                let mut length = [0; 2];
+                file.read_exact(&mut length)?;
+                let struct_length = length[1] as usize;
+                let mut entry_point_buffer = Vec::with_capacity(struct_length);
+                entry_point_buffer.resize(struct_length, 0);
+                file.seek(SeekFrom::Start(offset))?;
+                file.read_exact(&mut entry_point_buffer)?;
+                let entry_point: Self = entry_point_buffer.try_into()?;
+                return Ok(entry_point);
+            }
+        }
+        Err(Error::new(
+                ErrorKind::UnexpectedEof,
+                "Not found",
+            ))
     }
 }
 

--- a/src/core/smbios_data.rs
+++ b/src/core/smbios_data.rs
@@ -17,6 +17,17 @@ pub struct SMBiosData {
 impl<'a> SMBiosData {
     /// Creates an SMBIOS table parser which can be iterated
     ///
+    /// `table` is iterable table data.
+    /// `version` is optional and represents the DMTF SMBIOS Standard version of the bytes in `data`.
+    pub fn new(table: UndefinedStructTable, version: Option<SMBiosVersion>) -> Self {
+        Self {
+            table,
+            version,
+        }
+    }
+
+    /// Creates an SMBIOS table parser which can be iterated
+    ///
     /// `data` is a block of bytes representing the raw table data.
     /// `version` is optional and represents the DMTF SMBIOS Standard version of the bytes in `data`.
     pub fn from_vec_and_version(data: Vec<u8>, version: Option<SMBiosVersion>) -> Self {

--- a/src/core/undefined_struct.rs
+++ b/src/core/undefined_struct.rs
@@ -2,7 +2,12 @@ use super::header::{Handle, Header};
 use super::strings::Strings;
 use crate::structs::{DefinedStruct, SMBiosEndOfTable, SMBiosStruct};
 use std::fmt;
-use std::{convert::TryInto, slice::Iter, fs::File, io::{prelude::*, Error, ErrorKind, SeekFrom}};
+use std::{
+    convert::TryInto,
+    fs::File,
+    io::{prelude::*, Error, ErrorKind, SeekFrom},
+    slice::Iter,
+};
 
 /// # Embodies the three basic parts of an SMBIOS structure
 ///
@@ -303,9 +308,16 @@ impl<'a> UndefinedStructTable {
     }
 
     /// Load this structure by seeking and reading the file offsets.
-    pub fn try_load_range_from_file(file: &mut File, table_address: u64, table_len: usize) -> Result<Self, Error> {
+    pub fn try_load_range_from_file(
+        file: &mut File,
+        table_address: u64,
+        table_len: usize,
+    ) -> Result<Self, Error> {
         if table_len < Header::SIZE + 2 {
-            return Err(Error::new(ErrorKind::InvalidData, format!("The table has an invalid size: {}", table_len)))
+            return Err(Error::new(
+                ErrorKind::InvalidData,
+                format!("The table has an invalid size: {}", table_len),
+            ));
         }
 
         file.seek(SeekFrom::Start(table_address))?;

--- a/src/core/undefined_struct.rs
+++ b/src/core/undefined_struct.rs
@@ -307,10 +307,10 @@ impl<'a> UndefinedStructTable {
         self.defined_struct_iter().collect()
     }
 
-    /// Load this structure by seeking and reading the file offsets.
-    pub fn try_load_range_from_file(
+    /// Load an [UndefinedStructTable] by seeking and reading the file offsets.
+    pub fn try_load_from_file_offset(
         file: &mut File,
-        table_address: u64,
+        table_offset: u64,
         table_len: usize,
     ) -> Result<Self, Error> {
         if table_len < Header::SIZE + 2 {
@@ -320,7 +320,7 @@ impl<'a> UndefinedStructTable {
             ));
         }
 
-        file.seek(SeekFrom::Start(table_address))?;
+        file.seek(SeekFrom::Start(table_offset))?;
         let mut table = Vec::with_capacity(table_len);
         table.resize(table_len, 0);
         file.read_exact(&mut table)?;

--- a/src/core/undefined_struct.rs
+++ b/src/core/undefined_struct.rs
@@ -2,7 +2,7 @@ use super::header::{Handle, Header};
 use super::strings::Strings;
 use crate::structs::{DefinedStruct, SMBiosEndOfTable, SMBiosStruct};
 use std::fmt;
-use std::{convert::TryInto, slice::Iter};
+use std::{convert::TryInto, slice::Iter, fs::File, io::{prelude::*, Error, ErrorKind, SeekFrom}};
 
 /// # Embodies the three basic parts of an SMBIOS structure
 ///
@@ -300,6 +300,19 @@ impl<'a> UndefinedStructTable {
         T: SMBiosStruct<'a>,
     {
         self.defined_struct_iter().collect()
+    }
+
+    /// Load this structure by seeking and reading the file offsets.
+    pub fn try_load_range_from_file(file: &mut File, table_address: u64, table_len: usize) -> Result<Self, Error> {
+        if table_len < Header::SIZE + 2 {
+            return Err(Error::new(ErrorKind::InvalidData, format!("The table has an invalid size: {}", table_len)))
+        }
+
+        file.seek(SeekFrom::Start(table_address))?;
+        let mut table = Vec::with_capacity(table_len);
+        table.resize(table_len, 0);
+        file.read_exact(&mut table)?;
+        Ok(table.into())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,8 @@
 #![deny(rust_2018_idioms)]
 
 mod core;
-mod macos;
 mod file_io;
+mod macos;
 mod structs;
 mod unix;
 mod windows;
@@ -21,7 +21,7 @@ pub use crate::core::*;
 pub use file_io::*;
 
 #[cfg(target_family = "windows")]
-pub use windows::{load_windows_smbios_data, table_load_from_device, raw_smbios_from_device};
+pub use windows::{load_windows_smbios_data, raw_smbios_from_device, table_load_from_device};
 
 pub use windows::WinSMBiosData;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ pub use windows::{load_windows_smbios_data, table_load_from_device, raw_smbios_f
 
 pub use windows::WinSMBiosData;
 
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
 pub use unix::*;
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -1,7 +1,7 @@
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
 mod platform;
 
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
 pub use platform::*;
 
 pub use std::convert::TryInto;

--- a/src/unix/platform.rs
+++ b/src/unix/platform.rs
@@ -1,6 +1,5 @@
 use crate::*;
-use std::fs::read;
-use std::{io::Error, io::ErrorKind, path::Path};
+use std::{io::Error, io::ErrorKind};
 
     #[cfg(any(target_os = "linux"))]
     /// Full path to smbios_entry_point file on Linux (contains entry point data)
@@ -49,8 +48,9 @@ use std::{io::Error, io::ErrorKind, path::Path};
 /// Loads [SMBiosData] from the device via /sys/firmware/dmi/tables (on Linux)
 pub fn table_load_from_device() -> Result<SMBiosData, Error> {
     let version: SMBiosVersion;
+    let entry_path = std::path::Path::new(SYS_ENTRY_FILE);
 
-    match SMBiosEntryPoint64::try_load_from_file(Path::new(SYS_ENTRY_FILE)) {
+    match SMBiosEntryPoint64::try_load_from_file(entry_path) {
         Ok(entry_point) => {
             version = SMBiosVersion {
                 major: entry_point.major_version(),
@@ -60,7 +60,7 @@ pub fn table_load_from_device() -> Result<SMBiosData, Error> {
         }
         Err(err) => match err.kind() {
             ErrorKind::InvalidData => {
-                match SMBiosEntryPoint32::try_load_from_file(Path::new(SYS_ENTRY_FILE)) {
+                match SMBiosEntryPoint32::try_load_from_file(entry_path) {
                     Ok(entry_point) => {
                         version = SMBiosVersion {
                             major: entry_point.major_version(),
@@ -151,7 +151,7 @@ pub fn table_load_from_device() -> Result<SMBiosData, Error> {
 #[cfg(any(target_os = "linux"))]
 /// Returns smbios raw data via /sys/firmware/dmi/tables (on Linux)
 pub fn raw_smbios_from_device() -> Result<Vec<u8>, Error> {
-    Ok(read(SYS_TABLE_FILE)?)
+    Ok(std::fs::read(SYS_TABLE_FILE)?)
 }
 
 #[cfg(any(target_os = "freebsd"))]

--- a/src/unix/platform.rs
+++ b/src/unix/platform.rs
@@ -1,6 +1,6 @@
 use crate::*;
-use std::{io::Error, io::ErrorKind, path::Path};
 use std::fs::read;
+use std::{io::Error, io::ErrorKind, path::Path};
 
 const SYS_ENTRY_FILE: &'static str = "/sys/firmware/dmi/tables/smbios_entry_point";
 const SYS_TABLE_FILE: &'static str = "/sys/firmware/dmi/tables/DMI";
@@ -77,16 +77,24 @@ pub fn raw_smbios_from_device() -> Result<Vec<u8>, Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io;
     use std::fs::File;
+    use std::io;
 
     #[test]
     fn test_dev_mem_scan() -> io::Result<()> {
         let mut dev_mem = File::open(DEV_MEM_FILE)?;
         match SMBiosEntryPoint32::try_scan_from_file(&mut dev_mem, 0x000F0000..0x000FFFFF) {
             Ok(entry_point) => {
-                println!("SMBIOS {}.{} present.", entry_point.major_version(), entry_point.minor_version());
-                println!("{} structures occupying {} bytes.", entry_point.number_of_smbios_structures(), entry_point.structure_table_length());
+                println!(
+                    "SMBIOS {}.{} present.",
+                    entry_point.major_version(),
+                    entry_point.minor_version()
+                );
+                println!(
+                    "{} structures occupying {} bytes.",
+                    entry_point.number_of_smbios_structures(),
+                    entry_point.structure_table_length()
+                );
                 println!("Table at: {:#010X}.", entry_point.structure_table_address());
             }
             Err(error) => {
@@ -94,9 +102,18 @@ mod tests {
                     return Err(error);
                 }
 
-                let entry_point = SMBiosEntryPoint64::try_scan_from_file(&mut dev_mem, 0x000F0000..0x000FFFFF)?;
-                println!("SMBIOS {}.{}.{} present.", entry_point.major_version(), entry_point.minor_version(), entry_point.docrev());
-                println!("Occupying {} bytes maximum.", entry_point.structure_table_maximum_size());
+                let entry_point =
+                    SMBiosEntryPoint64::try_scan_from_file(&mut dev_mem, 0x000F0000..0x000FFFFF)?;
+                println!(
+                    "SMBIOS {}.{}.{} present.",
+                    entry_point.major_version(),
+                    entry_point.minor_version(),
+                    entry_point.docrev()
+                );
+                println!(
+                    "Occupying {} bytes maximum.",
+                    entry_point.structure_table_maximum_size()
+                );
                 println!("Table at: {:#010X}.", entry_point.structure_table_address());
             }
         }

--- a/src/unix/platform.rs
+++ b/src/unix/platform.rs
@@ -2,9 +2,16 @@ use crate::*;
 use std::fs::read;
 use std::{io::Error, io::ErrorKind, path::Path};
 
-const SYS_ENTRY_FILE: &'static str = "/sys/firmware/dmi/tables/smbios_entry_point";
-const SYS_TABLE_FILE: &'static str = "/sys/firmware/dmi/tables/DMI";
-const DEV_MEM_FILE: &'static str = "/dev/mem";
+    #[cfg(any(target_os = "linux"))]
+    /// Full path to smbios_entry_point file on Linux (contains entry point data)
+    pub const SYS_ENTRY_FILE: &'static str = "/sys/firmware/dmi/tables/smbios_entry_point";
+
+    #[cfg(any(target_os = "linux"))]
+    /// Full path to the DMI file on Linux (contains BIOS table data)
+    pub const SYS_TABLE_FILE: &'static str = "/sys/firmware/dmi/tables/DMI";
+
+    /// Full path to the memory device (contains BIOS entry point and table data on *nix platforms)
+    pub const DEV_MEM_FILE: &'static str = "/dev/mem";
 
 // Example of Linux structure:
 /*
@@ -42,6 +49,7 @@ const DEV_MEM_FILE: &'static str = "/dev/mem";
 /// Loads [SMBiosData] from the device via /sys/firmware/dmi/tables (on Linux)
 pub fn table_load_from_device() -> Result<SMBiosData, Error> {
     let version: SMBiosVersion;
+
     match SMBiosEntryPoint64::try_load_from_file(Path::new(SYS_ENTRY_FILE)) {
         Ok(entry_point) => {
             version = SMBiosVersion {
@@ -75,13 +83,17 @@ pub fn table_load_from_device() -> Result<SMBiosData, Error> {
 pub fn table_load_from_device() -> Result<SMBiosData, Error> {
     const RANGE_START: u64 = 0x000F0000u64;
     const RANGE_END: u64 = 0x000FFFFFu64;
-    let mut dev_mem = File::open(DEV_MEM_FILE)?;
     let structure_table_address: u64;
     let structure_table_length: u32;
     let version: SMBiosVersion;
 
+    let mut dev_mem = std::fs::File::open(DEV_MEM_FILE)?;
+
     match SMBiosEntryPoint32::try_scan_from_file(&mut dev_mem, RANGE_START..=RANGE_END) {
         Ok(entry_point) => {
+            structure_table_address = entry_point.structure_table_address() as u64;
+            structure_table_length = entry_point.structure_table_length() as u32;
+
            version = SMBiosVersion {
                 major: entry_point.major_version(),
                 minor: entry_point.minor_version(),
@@ -95,6 +107,9 @@ pub fn table_load_from_device() -> Result<SMBiosData, Error> {
 
             let entry_point =
                 SMBiosEntryPoint64::try_scan_from_file(&mut dev_mem, RANGE_START..=RANGE_END)?;
+
+            structure_table_address = entry_point.structure_table_address();
+            structure_table_length = entry_point.structure_table_maximum_size();
 
            version = SMBiosVersion {
                 major: entry_point.major_version(),
@@ -130,12 +145,77 @@ pub fn table_load_from_device() -> Result<SMBiosData, Error> {
         structure_table_length as usize,
     )?;
     
-    Ok(SMBiosData::from_vec_and_version(table.into_iter().collect(), version))
+    Ok(SMBiosData::new(table, Some(version)))
 }
 
-/// Returns smbios raw data
+#[cfg(any(target_os = "linux"))]
+/// Returns smbios raw data via /sys/firmware/dmi/tables (on Linux)
 pub fn raw_smbios_from_device() -> Result<Vec<u8>, Error> {
     Ok(read(SYS_TABLE_FILE)?)
+}
+
+#[cfg(any(target_os = "freebsd"))]
+/// Returns smbios raw data via /sys/firmware/dmi/tables (on Linux)
+pub fn raw_smbios_from_device() -> Result<Vec<u8>, Error> {
+    use std::io::{prelude::*, SeekFrom};
+    const RANGE_START: u64 = 0x000F0000u64;
+    const RANGE_END: u64 = 0x000FFFFFu64;
+    let structure_table_address: u64;
+    let structure_table_length: usize;
+
+    let mut dev_mem = std::fs::File::open(DEV_MEM_FILE)?;
+
+    match SMBiosEntryPoint32::try_scan_from_file(&mut dev_mem, RANGE_START..=RANGE_END) {
+        Ok(entry_point) => {
+            structure_table_address = entry_point.structure_table_address() as u64;
+            structure_table_length = entry_point.structure_table_length() as usize;
+        }
+        Err(error) => {
+            if error.kind() != ErrorKind::UnexpectedEof {
+                return Err(error);
+            }
+
+            let entry_point =
+                SMBiosEntryPoint64::try_scan_from_file(&mut dev_mem, RANGE_START..=RANGE_END)?;
+
+            structure_table_address = entry_point.structure_table_address();
+            structure_table_length = entry_point.structure_table_maximum_size() as usize;
+        }
+    }
+
+    if structure_table_address < RANGE_START || structure_table_address > RANGE_END {
+        return Err(Error::new(
+            ErrorKind::InvalidData,
+            format!(
+                "The entry point has given an out of range start address for the table: {}",
+                structure_table_address
+            ),
+        ));
+    }
+
+    if structure_table_address + structure_table_length as u64 > RANGE_END {
+        return Err(Error::new(
+            ErrorKind::InvalidData,
+            format!(
+                "The entry point has given a length which exceeds the range: {}",
+                structure_table_length
+            ),
+        ));
+    }
+
+    if structure_table_length < Header::SIZE + 2 {
+        return Err(Error::new(
+            ErrorKind::InvalidData,
+            format!("The table has an invalid size: {}", structure_table_length),
+        ));
+    }
+
+    dev_mem.seek(SeekFrom::Start(structure_table_address))?;
+    let mut table = Vec::with_capacity(structure_table_length);
+    table.resize(structure_table_length, 0);
+    dev_mem.read_exact(&mut table)?;
+
+    Ok(table)
 }
 
 #[cfg(test)]

--- a/src/unix/platform.rs
+++ b/src/unix/platform.rs
@@ -82,8 +82,8 @@ mod tests {
 
     #[test]
     fn test_dev_mem_scan() -> io::Result<()> {
-        const RANGE_START:u64 = 0x000F0000u64;
-        const RANGE_END:u64 = 0x000FFFFFu64;
+        const RANGE_START: u64 = 0x000F0000u64;
+        const RANGE_END: u64 = 0x000FFFFFu64;
         let mut dev_mem = File::open(DEV_MEM_FILE)?;
         let mut structure_table_address: u64 = 0;
         let mut structure_table_length: u32 = 0;
@@ -130,14 +130,30 @@ mod tests {
         }
 
         if structure_table_address < RANGE_START || structure_table_address > RANGE_END {
-            return Err(Error::new(ErrorKind::InvalidData, format!("The entry point has given an out of range start address for the table: {}", structure_table_address)));
+            return Err(Error::new(
+                ErrorKind::InvalidData,
+                format!(
+                    "The entry point has given an out of range start address for the table: {}",
+                    structure_table_address
+                ),
+            ));
         }
 
         if structure_table_address + structure_table_length as u64 > RANGE_END {
-            return Err(Error::new(ErrorKind::InvalidData, format!("The entry point has given a length which exceeds the range: {}", structure_table_length)));
+            return Err(Error::new(
+                ErrorKind::InvalidData,
+                format!(
+                    "The entry point has given a length which exceeds the range: {}",
+                    structure_table_length
+                ),
+            ));
         }
 
-        let table = UndefinedStructTable::try_load_range_from_file(&mut dev_mem, structure_table_address, structure_table_length as usize)?;
+        let table = UndefinedStructTable::try_load_range_from_file(
+            &mut dev_mem,
+            structure_table_address,
+            structure_table_length as usize,
+        )?;
         println!("{:#X?}", table);
 
         Ok(())

--- a/src/unix/platform.rs
+++ b/src/unix/platform.rs
@@ -85,8 +85,8 @@ mod tests {
         const RANGE_START: u64 = 0x000F0000u64;
         const RANGE_END: u64 = 0x000FFFFFu64;
         let mut dev_mem = File::open(DEV_MEM_FILE)?;
-        let mut structure_table_address: u64 = 0;
-        let mut structure_table_length: u32 = 0;
+        let structure_table_address: u64;
+        let structure_table_length: u32;
 
         match SMBiosEntryPoint32::try_scan_from_file(&mut dev_mem, RANGE_START..=RANGE_END) {
             Ok(entry_point) => {

--- a/src/unix/platform.rs
+++ b/src/unix/platform.rs
@@ -155,7 +155,7 @@ pub fn raw_smbios_from_device() -> Result<Vec<u8>, Error> {
 }
 
 #[cfg(any(target_os = "freebsd"))]
-/// Returns smbios raw data via /sys/firmware/dmi/tables (on Linux)
+/// Returns smbios raw data via /dev/mem (on FreeBSD)
 pub fn raw_smbios_from_device() -> Result<Vec<u8>, Error> {
     use std::io::{prelude::*, SeekFrom};
     const RANGE_START: u64 = 0x000F0000u64;

--- a/src/windows/platform.rs
+++ b/src/windows/platform.rs
@@ -24,7 +24,7 @@ mod ffi {
 pub fn load_windows_smbios_data() -> Result<WinSMBiosData, Error> {
     match raw_smbios_from_device() {
         Ok(raw) => WinSMBiosData::new(raw),
-        Err(e) => Err(e)
+        Err(e) => Err(e),
     }
 }
 


### PR DESCRIPTION
Example output from the test:
```
running 1 test
SMBIOS 2.3 present.
338 structures occupying 17307 bytes.
Table at: 0x000F93D0.
UndefinedStructTable(
    [
        smbioslib::core::undefined_struct::UndefinedStruct {
            header: smbioslib::core::header::Header {
                struct_type: 0x0,
                length: 0x14,
                handle: Handle(
                    0x0,
                ),
            },
...
```

dmidecode original displays exactly the same when it runs:
```
SMBIOS 2.3 present.
338 structures occupying 17307 bytes.
Table at: 0x000F93D0.
```

These formatted strings should live in dmidecode-rs and not in smbios-lib because a library shouldn't be concerned with UI implementation.  To address this, the API of smbios-lib should expose the pieces individually, namely, the entry point structures and the table structure.

The first/current smbios-lib API design assumes a user is only interested the end product, the table, and that the entry point information would be thrown away during that process of retrieving the table because the purpose of the entry point is to find the table.  This thought did not consider the user scenario of someone interested in debugging information - like what dmidecode original shows in its output.

Because the entry point and table are found in the same file, and there are two operations to be performed on that file, the new API takes a File object as input (someone must open a file before calling these functions) and instruct the functions where to look for the entry point and the table.  So I've used the [RangeBounds](https://doc.rust-lang.org/std/ops/trait.RangeBounds.html) trait as input search range for finding the entry point.  This enables someone to use the Rust language range expressions like "start..end" or "start..=end" or "..end" etc.

The SMBios specification states (see the code comments on the entry point structs) that the range will normally be 0x000F0000 to 0x000FFFFF.  But if there are other cases I thought it would make sense to allow the user to specify the range.

FreeBSD only works with /dev/mem.  The current "load_table_from_device()" would be wasteful to try first loading from sysfs and then try from /dev/mem on a FreeBSD device.  We now compile for FreeBSD explicitly or Linux explicitly and therefore, the design optimizes per platform needs.  It doesn't make a lot of sense for dmidecode-rs on FreeBSD to have options to suppress use of sysfs if it doesn't have it.  So some organization needs to be done in dmidecode-rs after this PR.