### PR TITLE
[WIP] Experimenting with JSON and BIOS structures patterns

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ path = "src/main.rs"
 
 [dependencies]
 getopts = "0.2.21"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1.0"
 
 [target.'cfg(windows)'.dependencies]
 libc = "0.2"

--- a/src/core/header.rs
+++ b/src/core/header.rs
@@ -1,3 +1,4 @@
+use serde::{ser::SerializeStruct, Serialize, Serializer};
 use std::{convert::TryInto, fmt, ops::Deref, str::FromStr};
 
 /// # Structure Handle
@@ -6,12 +7,24 @@ use std::{convert::TryInto, fmt, ops::Deref, str::FromStr};
 /// Some structures will reference other structures by using this value.
 ///
 /// Dereference a handle (*handle) to access its u16 value.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Serialize, PartialEq, Eq)]
 pub struct Handle(pub u16);
 
 impl Handle {
     /// Handle Size (2 bytes)
     pub const SIZE: usize = 2usize;
+}
+
+impl fmt::Debug for Handle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", &self.0)
+    }
+}
+
+impl fmt::Display for Handle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", &self.0)
+    }
 }
 
 impl Deref for Handle {
@@ -69,6 +82,19 @@ impl fmt::Debug for Header {
             .field("length", &self.length())
             .field("handle", &self.handle())
             .finish()
+    }
+}
+
+impl Serialize for Header {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut state = serializer.serialize_struct("Header", 3)?;
+        state.serialize_field("struct_type", &self.struct_type())?;
+        state.serialize_field("length", &self.length())?;
+        state.serialize_field("handle", &self.handle())?;
+        state.end()
     }
 }
 

--- a/src/core/smbios_data.rs
+++ b/src/core/smbios_data.rs
@@ -4,10 +4,12 @@ use crate::structs::{DefinedStructTable, SMBiosStruct};
 use std::io::Error;
 use std::{cmp::Ordering, slice::Iter};
 use std::{fmt, fs::read};
+use serde::Serialize;
 
 /// # SMBIOS Data
 ///
 /// Contains an optional SMBIOS version and a collection of SMBIOS structures.
+#[derive(Serialize)]
 pub struct SMBiosData {
     table: UndefinedStructTable,
     /// Version of the contained SMBIOS structures.
@@ -170,7 +172,7 @@ impl fmt::Debug for SMBiosData {
 }
 
 /// # Version of SMBIOS Structure
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Serialize)]
 pub struct SMBiosVersion {
     /// SMBIOS major version
     pub major: u8,

--- a/src/core/undefined_struct.rs
+++ b/src/core/undefined_struct.rs
@@ -8,7 +8,7 @@ use std::{
     io::{prelude::*, Error, ErrorKind, SeekFrom},
     slice::Iter,
 };
-
+use serde::{Serialize, Serializer};
 /// # Embodies the three basic parts of an SMBIOS structure
 ///
 /// Every SMBIOS structure contains three distinct sections:
@@ -23,8 +23,10 @@ use std::{
 /// necessary.  Therefore, [UndefinedStruct] is public for the case of OEM,
 /// as well as when working with structures that are defined in an SMBIOS
 /// standard newer than the one this library currently supports.
+#[derive(Serialize)]
 pub struct UndefinedStruct {
     /// The [Header] of the structure
+    #[serde(serialize_with = "ser_header")]
     pub header: Header,
 
     /// The raw data for the header and fields
@@ -47,8 +49,25 @@ pub struct UndefinedStruct {
     pub fields: Vec<u8>,
 
     /// The strings of the structure
+    #[serde(serialize_with = "ser_strings")]
     pub strings: Strings,
 }
+
+fn ser_header<S>(data: &Header, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+{
+    serializer.serialize_str(format!("{:?}", data).as_str())
+}
+
+
+fn ser_strings<S>(data: &Strings, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+{
+    serializer.serialize_str(format!("{:?}", data).as_str())
+}
+
 
 impl<'a> UndefinedStruct {
     /// Creates a structure instance of the given byte array slice
@@ -184,7 +203,7 @@ impl Default for UndefinedStruct {
 /// # Undefined Struct Table
 ///
 /// A collection of [UndefinedStruct] items.
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct UndefinedStructTable(Vec<UndefinedStruct>);
 
 impl<'a> UndefinedStructTable {

--- a/src/core/undefined_struct.rs
+++ b/src/core/undefined_struct.rs
@@ -1,6 +1,7 @@
 use super::header::{Handle, Header};
 use super::strings::Strings;
 use crate::structs::{DefinedStruct, SMBiosEndOfTable, SMBiosStruct};
+use serde::{Serialize, Serializer};
 use std::fmt;
 use std::{
     convert::TryInto,
@@ -8,7 +9,6 @@ use std::{
     io::{prelude::*, Error, ErrorKind, SeekFrom},
     slice::Iter,
 };
-use serde::{Serialize, Serializer};
 /// # Embodies the three basic parts of an SMBIOS structure
 ///
 /// Every SMBIOS structure contains three distinct sections:
@@ -26,7 +26,6 @@ use serde::{Serialize, Serializer};
 #[derive(Serialize)]
 pub struct UndefinedStruct {
     /// The [Header] of the structure
-    #[serde(serialize_with = "ser_header")]
     pub header: Header,
 
     /// The raw data for the header and fields
@@ -53,21 +52,12 @@ pub struct UndefinedStruct {
     pub strings: Strings,
 }
 
-fn ser_header<S>(data: &Header, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-{
-    serializer.serialize_str(format!("{:?}", data).as_str())
-}
-
-
 fn ser_strings<S>(data: &Strings, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
+where
+    S: Serializer,
 {
     serializer.serialize_str(format!("{:?}", data).as_str())
 }
-
 
 impl<'a> UndefinedStruct {
     /// Creates a structure instance of the given byte array slice

--- a/src/main.rs
+++ b/src/main.rs
@@ -220,8 +220,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     match matches.opt_str(string_option) {
         Some(keyword) => {
             let smbios_data = table_load_from_device()?;
-            let output = string_keyword(keyword, &smbios_data)?;
-            println!("{}", output);
+            // let raw_data = raw_smbios_from_device()?;
+            let outjson = serde_json::to_string(&smbios_data);
+            // let output = string_keyword(keyword, &smbios_data)?;
+            // println!("{}", output);
+            println!("{}", outjson?);
         }
         None => (),
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -179,6 +179,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let file_option = "f";
     let output_option = "o";
     let string_option = "s";
+    let json_option = "j";
 
     let args: Vec<String> = std::env::args().collect();
     let mut opts = getopts::Options::new();
@@ -190,12 +191,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "Only display the value of the DMI string identified by KEYWORD.",
         "KEYWORD",
     );
+    opts.optflag(json_option, "", "output in json format");
 
     let matches = opts.parse(&args[1..])?;
 
     if !matches.opt_present(file_option)
         && !matches.opt_present(output_option)
         && !matches.opt_present(string_option)
+        && !matches.opt_present(json_option)
     {
         println!("table_data: {:#?}", table_load_from_device()?);
         return Ok(());
@@ -220,13 +223,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     match matches.opt_str(string_option) {
         Some(keyword) => {
             let smbios_data = table_load_from_device()?;
-            // let raw_data = raw_smbios_from_device()?;
-            let outjson = serde_json::to_string(&smbios_data);
-            // let output = string_keyword(keyword, &smbios_data)?;
-            // println!("{}", output);
-            println!("{}", outjson?);
+            let output = string_keyword(keyword, &smbios_data)?;
+            println!("{}", output);
         }
         None => (),
+    }
+    if matches.opt_present(json_option) {
+        let smbios_data = table_load_from_device()?;
+        if let Ok(output) = serde_json::to_string(&smbios_data) {
+            println!("{}", output)
+        }
     }
 
     Ok(())

--- a/src/structs/types/baseboard_information.rs
+++ b/src/structs/types/baseboard_information.rs
@@ -132,6 +132,15 @@ impl fmt::Debug for BoardTypeData {
     }
 }
 
+impl fmt::Display for BoardTypeData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.value {
+            BoardType::None => write!(f, "{}", &self.raw),
+            _ => write!(f, "{:?}", &self.value),
+        }
+    }
+}
+
 impl Deref for BoardTypeData {
     type Target = BoardType;
 

--- a/src/structs/types/built_in_pointing_device.rs
+++ b/src/structs/types/built_in_pointing_device.rs
@@ -83,6 +83,15 @@ impl fmt::Debug for PointingDeviceTypeData {
     }
 }
 
+impl fmt::Display for PointingDeviceTypeData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.value {
+            PointingDeviceType::None => write!(f, "{}", &self.raw),
+            _ => write!(f, "{:?}", &self.value),
+        }
+    }
+}
+
 impl Deref for PointingDeviceTypeData {
     type Target = PointingDeviceType;
 

--- a/src/structs/types/cache_information.rs
+++ b/src/structs/types/cache_information.rs
@@ -235,6 +235,15 @@ impl fmt::Debug for SystemCacheTypeData {
     }
 }
 
+impl fmt::Display for SystemCacheTypeData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.value {
+            SystemCacheType::None => write!(f, "{}", &self.raw),
+            _ => write!(f, "{:?}", &self.value),
+        }
+    }
+}
+
 impl Deref for SystemCacheTypeData {
     type Target = SystemCacheType;
 
@@ -295,6 +304,15 @@ impl fmt::Debug for ErrorCorrectionTypeData {
             .field("raw", &self.raw)
             .field("value", &self.value)
             .finish()
+    }
+}
+
+impl fmt::Display for ErrorCorrectionTypeData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.value {
+            ErrorCorrectionType::None => write!(f, "{}", &self.raw),
+            _ => write!(f, "{:?}", &self.value),
+        }
     }
 }
 

--- a/src/structs/types/ipmi_device_information.rs
+++ b/src/structs/types/ipmi_device_information.rs
@@ -251,6 +251,15 @@ impl fmt::Debug for IpmiInterfaceTypeData {
     }
 }
 
+impl fmt::Display for IpmiInterfaceTypeData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.value {
+            IpmiInterfaceType::None => write!(f, "{}", &self.raw),
+            _ => write!(f, "{:?}", &self.value),
+        }
+    }
+}
+
 impl Deref for IpmiInterfaceTypeData {
     type Target = IpmiInterfaceType;
 

--- a/src/structs/types/management_controller_host_interface.rs
+++ b/src/structs/types/management_controller_host_interface.rs
@@ -172,6 +172,15 @@ impl fmt::Debug for HostInterfaceTypeData {
     }
 }
 
+impl fmt::Display for HostInterfaceTypeData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.value {
+            HostInterfaceType::None => write!(f, "{}", &self.raw),
+            _ => write!(f, "{:?}", &self.value),
+        }
+    }
+}
+
 impl Deref for HostInterfaceTypeData {
     type Target = HostInterfaceType;
 
@@ -267,6 +276,15 @@ impl fmt::Debug for HostProtocolTypeData {
             .field("raw", &self.raw)
             .field("value", &self.value)
             .finish()
+    }
+}
+
+impl fmt::Display for HostProtocolTypeData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.value {
+            HostProtocolType::None => write!(f, "{}", &self.raw),
+            _ => write!(f, "{:?}", &self.value),
+        }
     }
 }
 

--- a/src/structs/types/management_device.rs
+++ b/src/structs/types/management_device.rs
@@ -85,6 +85,15 @@ impl fmt::Debug for ManagementDeviceTypeData {
     }
 }
 
+impl fmt::Display for ManagementDeviceTypeData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.value {
+            ManagementDeviceType::None => write!(f, "{}", &self.raw),
+            _ => write!(f, "{:?}", &self.value),
+        }
+    }
+}
+
 impl Deref for ManagementDeviceTypeData {
     type Target = ManagementDeviceType;
 
@@ -169,6 +178,15 @@ impl fmt::Debug for ManagementDeviceAddressTypeData {
             .field("raw", &self.raw)
             .field("value", &self.value)
             .finish()
+    }
+}
+
+impl fmt::Display for ManagementDeviceAddressTypeData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.value {
+            ManagementDeviceAddressType::None => write!(f, "{}", &self.raw),
+            _ => write!(f, "{:?}", &self.value),
+        }
     }
 }
 

--- a/src/structs/types/memory_channel.rs
+++ b/src/structs/types/memory_channel.rs
@@ -97,6 +97,15 @@ impl fmt::Debug for MemoryChannelTypeData {
     }
 }
 
+impl fmt::Display for MemoryChannelTypeData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.value {
+            MemoryChannelType::None => write!(f, "{}", &self.raw),
+            _ => write!(f, "{:?}", &self.value),
+        }
+    }
+}
+
 impl Deref for MemoryChannelTypeData {
     type Target = MemoryChannelType;
 

--- a/src/structs/types/memory_device.rs
+++ b/src/structs/types/memory_device.rs
@@ -390,6 +390,15 @@ impl fmt::Debug for MemoryDeviceTypeData {
     }
 }
 
+impl fmt::Display for MemoryDeviceTypeData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.value {
+            MemoryDeviceType::None => write!(f, "{}", &self.raw),
+            _ => write!(f, "{:?}", &self.value),
+        }
+    }
+}
+
 impl Deref for MemoryDeviceTypeData {
     type Target = MemoryDeviceType;
 

--- a/src/structs/types/memory_error_information_32.rs
+++ b/src/structs/types/memory_error_information_32.rs
@@ -123,6 +123,15 @@ impl fmt::Debug for MemoryErrorTypeData {
     }
 }
 
+impl fmt::Display for MemoryErrorTypeData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.value {
+            MemoryErrorType::None => write!(f, "{}", &self.raw),
+            _ => write!(f, "{:?}", &self.value),
+        }
+    }
+}
+
 impl Deref for MemoryErrorTypeData {
     type Target = MemoryErrorType;
 

--- a/src/structs/types/port_connector_information.rs
+++ b/src/structs/types/port_connector_information.rs
@@ -106,6 +106,15 @@ impl fmt::Debug for PortInformationConnectorTypeData {
     }
 }
 
+impl fmt::Display for PortInformationConnectorTypeData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.value {
+            PortInformationConnectorType::None => write!(f, "{}", &self.raw),
+            _ => write!(f, "{:?}", &self.value),
+        }
+    }
+}
+
 impl Deref for PortInformationConnectorTypeData {
     type Target = PortInformationConnectorType;
 
@@ -277,6 +286,15 @@ impl fmt::Debug for PortInformationPortTypeData {
             .field("raw", &self.raw)
             .field("value", &self.value)
             .finish()
+    }
+}
+
+impl fmt::Display for PortInformationPortTypeData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.value {
+            PortInformationPortType::None => write!(f, "{}", &self.raw),
+            _ => write!(f, "{:?}", &self.value),
+        }
     }
 }
 

--- a/src/structs/types/processor_additional_information.rs
+++ b/src/structs/types/processor_additional_information.rs
@@ -147,6 +147,15 @@ impl fmt::Debug for ProcessorArchitectureTypeData {
     }
 }
 
+impl fmt::Display for ProcessorArchitectureTypeData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.value {
+            ProcessorArchitectureType::None => write!(f, "{}", &self.raw),
+            _ => write!(f, "{:?}", &self.value),
+        }
+    }
+}
+
 impl Deref for ProcessorArchitectureTypeData {
     type Target = ProcessorArchitectureType;
 

--- a/src/structs/types/processor_information.rs
+++ b/src/structs/types/processor_information.rs
@@ -345,6 +345,15 @@ impl fmt::Debug for ProcessorTypeData {
     }
 }
 
+impl fmt::Display for ProcessorTypeData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.value {
+            ProcessorType::None => write!(f, "{}", &self.raw),
+            _ => write!(f, "{:?}", &self.value),
+        }
+    }
+}
+
 impl Deref for ProcessorTypeData {
     type Target = ProcessorType;
 

--- a/src/structs/types/system_chassis_information.rs
+++ b/src/structs/types/system_chassis_information.rs
@@ -273,7 +273,10 @@ impl fmt::Debug for ChassisTypeData {
 
 impl fmt::Display for ChassisTypeData {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "raw: {}, value: {:?}", &self.raw, &self.value)
+        match &self.value {
+            ChassisType::None => write!(f, "{}", &self.raw),
+            _ => write!(f, "{:?}", &self.value),
+        }
     }
 }
 

--- a/src/structs/types/system_chassis_information.rs
+++ b/src/structs/types/system_chassis_information.rs
@@ -257,9 +257,9 @@ pub struct ChassisTypeData {
     /// This is most likely to occur when the standard was updated but
     /// this library code has not been updated to match the current
     /// standard.
-    raw: u8,
+    pub raw: u8,
     /// The contained [ChassisType] value
-    value: ChassisType,
+    pub value: ChassisType,
 }
 
 impl fmt::Debug for ChassisTypeData {

--- a/src/structs/types/system_event_log.rs
+++ b/src/structs/types/system_event_log.rs
@@ -176,6 +176,15 @@ impl fmt::Debug for LogTypeData {
     }
 }
 
+impl fmt::Display for LogTypeData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.value {
+            LogType::None => write!(f, "{}", &self.raw),
+            _ => write!(f, "{:?}", &self.value),
+        }
+    }
+}
+
 impl Deref for LogTypeData {
     type Target = LogType;
 
@@ -290,6 +299,15 @@ impl fmt::Debug for VariableDataFormatTypeData {
             .field("raw", &self.raw)
             .field("value", &self.value)
             .finish()
+    }
+}
+
+impl fmt::Display for VariableDataFormatTypeData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.value {
+            VariableDataFormatType::None => write!(f, "{}", &self.raw),
+            _ => write!(f, "{:?}", &self.value),
+        }
     }
 }
 

--- a/src/structs/types/system_information.rs
+++ b/src/structs/types/system_information.rs
@@ -151,11 +151,10 @@ impl fmt::Display for SystemUuidData {
         match &*self {
             SystemUuidData::IdNotPresent => write!(f, "IdNotPresent"),
             SystemUuidData::IdNotPresentButSettable => write!(f, "IdNotPresentButSettable"),
-            SystemUuidData::Uuid(_system_uuid) => write!(f, "{}", &_system_uuid)
+            SystemUuidData::Uuid(_system_uuid) => write!(f, "{}", &_system_uuid),
         }
     }
 }
-
 
 /// # System - UUID
 #[derive(PartialEq, Eq)]
@@ -229,7 +228,6 @@ impl fmt::Debug for SystemUuid {
     }
 }
 
-
 /// # System - Wake-up Type Data
 pub struct SystemWakeUpTypeData {
     /// Raw value
@@ -249,6 +247,15 @@ impl fmt::Debug for SystemWakeUpTypeData {
             .field("raw", &self.raw)
             .field("value", &self.value)
             .finish()
+    }
+}
+
+impl fmt::Display for SystemWakeUpTypeData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.value {
+            SystemWakeUpType::None => write!(f, "{}", &self.raw),
+            _ => write!(f, "{:?}", &self.value),
+        }
     }
 }
 

--- a/src/structs/types/system_slot.rs
+++ b/src/structs/types/system_slot.rs
@@ -294,6 +294,15 @@ impl fmt::Debug for SystemSlotTypeData {
     }
 }
 
+impl fmt::Display for SystemSlotTypeData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.value {
+            SystemSlotType::None => write!(f, "{}", &self.raw),
+            _ => write!(f, "{:?}", &self.value),
+        }
+    }
+}
+
 /// # System Slot Type
 #[derive(Debug, PartialEq, Eq)]
 pub enum SystemSlotType {


### PR DESCRIPTION
 I played with serde a little tonight, I found a coding pattern:
```rust
impl fmt::Debug for Header {
    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
        fmt.debug_struct(std::any::type_name::<Header>())
            .field("struct_type", &self.struct_type())
            .field("length", &self.length())
            .field("handle", &self.handle())
            .finish()
    }
}

impl Serialize for Header {
    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
    where
        S: Serializer,
    {
        let mut state = serializer.serialize_struct("Header", 3)?;
        state.serialize_field("struct_type", &self.struct_type())?;
        state.serialize_field("length", &self.length())?;
        state.serialize_field("handle", &self.handle())?;
        state.end()
    }
}
```

For each structure that has a custom Debug, we can copy the format of it quite closely, shown above.  I can write a small app to identify the pattern and add code like this. The output looks like:
```
Finished dev [unoptimized + debuginfo] target(s) in 0.12s
     Running `target\debug\smbiosdump.exe -j`
{"table":[{"header":{"struct_type":18,"length":23,"handle":0},"fields":[18,23,0,0,3,2,2,0,0,0,0,0,0,0,128,0,0,0,128,0,0,0,128],"strings":"[]"},{"header":{"struct_type":16,"length":23,"handle":1},"fields":[16,23,1,0,3,3,3,0,0,0,4,0,0,2,0,0,0,0,0,0,0,0,0],"strings":"[]"},{"header":{"struct_type":19,"length":31,"handle":2},"fields":[19,31,2,0,0,0,0,0,255,255,255,0,1,0,2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"strings":"[]"},{"header":{"struct_type":7,"length":27,"handle":3},"fields":[7,27,3,0,1,128,1,128,1,128,1,16,0,16,0,1,6,5,7,128,1,0,0,128,1,0,0],"strings":"[\"L1 - Cache\"]"}
... etc.
```