### PR TITLE
Improve usability of smbios-lib from dmidecode for pub and version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smbios-lib"
-version = "0.7.4"
+version = "0.7.5"
 authors = ["Jeffrey R. Gerber <jeffreygerber@gmail.com>", "Ante Čulo <dante2711@gmail.com>", "Juan Zuluaga <juzuluag@hotmail.com>"]
 license-file = "LICENSE"
 edition = "2018"

--- a/src/core/smbios_data.rs
+++ b/src/core/smbios_data.rs
@@ -183,7 +183,7 @@ impl Serialize for SMBiosData {
 }
 
 /// # Version of SMBIOS Structure
-#[derive(Debug, Eq, PartialEq, Serialize)]
+#[derive(Debug, Eq, PartialEq, Serialize, Clone, Copy)]
 pub struct SMBiosVersion {
     /// SMBIOS major version
     pub major: u8,
@@ -191,6 +191,17 @@ pub struct SMBiosVersion {
     pub minor: u8,
     /// SMBIOS version revision
     pub revision: u8,
+}
+
+impl SMBiosVersion {
+    /// Creates a new [SMBiosVersion] struct
+    pub fn new(major: u8, minor: u8, revision: u8) -> SMBiosVersion {
+        SMBiosVersion {
+            major,
+            minor,
+            revision,
+        }
+    }
 }
 
 impl Ord for SMBiosVersion {

--- a/src/structs/types/baseboard_information.rs
+++ b/src/structs/types/baseboard_information.rs
@@ -250,7 +250,13 @@ pub enum BoardType {
 /// # Baseboard Features
 #[derive(PartialEq, Eq)]
 pub struct BaseboardFeatures {
-    raw: u8,
+    /// Raw value
+    ///
+    /// _raw_ is useful when there are values not yet defiend.
+    /// This is most likely to occur when the standard was updated but
+    /// this library code has not been updated to match the current
+    /// standard.
+    pub raw: u8,
 }
 
 impl Deref for BaseboardFeatures {

--- a/src/structs/types/system_slot.rs
+++ b/src/structs/types/system_slot.rs
@@ -213,9 +213,9 @@ pub struct SystemSlotTypeData {
     /// This is most likely to occur when the standard was updated but
     /// this library code has not been updated to match the current
     /// standard.
-    raw: u8,
+    pub raw: u8,
     /// The contained [SystemSlotType] value
-    value: SystemSlotType,
+    pub value: SystemSlotType,
 }
 
 impl Deref for SystemSlotTypeData {
@@ -761,7 +761,10 @@ pub enum SlotLength {
 /// # System Slot Characteristics 1
 #[derive(PartialEq, Eq)]
 pub struct SystemSlotCharacteristics1 {
-    raw: u8,
+    /// Raw value
+    ///
+    /// _raw_ is useful for masked comparisons.
+    pub raw: u8,
 }
 
 impl Deref for SystemSlotCharacteristics1 {
@@ -864,7 +867,13 @@ impl Serialize for SystemSlotCharacteristics1 {
 /// # System Slot Characteristics 2
 #[derive(PartialEq, Eq)]
 pub struct SystemSlotCharacteristics2 {
-    raw: u8,
+    /// Raw value
+    ///
+    /// _raw_ is useful when there are values not yet defiend.
+    /// This is most likely to occur when the standard was updated but
+    /// this library code has not been updated to match the current
+    /// standard.
+    pub raw: u8,
 }
 
 impl Deref for SystemSlotCharacteristics2 {

--- a/src/structs/types/tpm_device.rs
+++ b/src/structs/types/tpm_device.rs
@@ -184,7 +184,13 @@ impl<'a> Serialize for VendorId<'a> {
 /// # TPM Device Characteristics
 #[derive(PartialEq, Eq)]
 pub struct TpmDeviceCharacteristics {
-    raw: u64,
+    /// Raw value
+    ///
+    /// _raw_ is useful when there are values not yet defiend.
+    /// This is most likely to occur when the standard was updated but
+    /// this library code has not been updated to match the current
+    /// standard.
+    pub raw: u64,
 }
 
 impl Deref for TpmDeviceCharacteristics {


### PR DESCRIPTION
- Some fields could not be queried because they were not `pub`.
- Some decisions need to be made based on the BIOS version and working with `SMBiosVersion` was a bit clumsy