### PR TITLE
Create SystemSlotId type and fix docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smbios-lib"
-version = "0.7.6"
+version = "0.7.7"
 authors = ["Jeffrey R. Gerber <jeffreygerber@gmail.com>", "Ante Čulo <dante2711@gmail.com>", "Juan Zuluaga <juzuluag@hotmail.com>"]
 license-file = "LICENSE"
 edition = "2018"

--- a/src/structs/types/end_of_table.rs
+++ b/src/structs/types/end_of_table.rs
@@ -1,5 +1,5 @@
-use serde::{ser::SerializeStruct, Serialize, Serializer};
 use crate::{SMBiosStruct, UndefinedStruct};
+use serde::{ser::SerializeStruct, Serialize, Serializer};
 use std::fmt;
 
 /// # End-of-Table (Type 127)
@@ -8,7 +8,7 @@ use std::fmt;
 ///
 /// To ensure backward compatibility with management software written to previous versions of this
 /// specification, a system implementation should use the end-of-table indicator in a manner similar to the
-/// [SMBiosInactive] (Type 126) structure type; the structure table is still reported as a fixed-length, and the entire
+/// [super::SMBiosInactive] (Type 126) structure type; the structure table is still reported as a fixed-length, and the entire
 /// length of the table is still indexable. If the end-of-table indicator is used in the last physical structure in a
 /// table, the field’s length is encoded as 4.
 ///
@@ -47,7 +47,7 @@ impl Serialize for SMBiosEndOfTable<'_> {
         S: Serializer,
     {
         let mut state = serializer.serialize_struct("SMBiosEndOfTable", 1)?;
-            state.serialize_field("header", &self.parts.header)?;
-            state.end()
+        state.serialize_field("header", &self.parts.header)?;
+        state.end()
     }
 }

--- a/src/structs/types/memory_channel.rs
+++ b/src/structs/types/memory_channel.rs
@@ -6,7 +6,7 @@ use std::ops::Deref;
 
 /// # Memory Channel (Type 37)
 ///
-/// The information in this structure provides the correlation between a Memory Channel and its associated [SMBiosMemoryDevice]s.
+/// The information in this structure provides the correlation between a Memory Channel and its associated [super::SMBiosMemoryDevice]s.
 ///
 /// Each device presents one or more loads to the channel; the sum of all device loads cannot exceed the channel’s defined maximum.
 ///
@@ -45,7 +45,7 @@ impl<'a> SMBiosMemoryChannel<'a> {
         self.parts.get_field_byte(0x05)
     }
 
-    /// Number of [SMBiosMemoryDevice]s (Type 11h) that are
+    /// Number of [super::SMBiosMemoryDevice]s (Type 11h) that are
     /// associated with this channel
     ///
     /// This value also defines the number of Load/Handle pairs
@@ -54,7 +54,7 @@ impl<'a> SMBiosMemoryChannel<'a> {
         self.parts.get_field_byte(0x06)
     }
 
-    /// Load/Handle pairs defining the [SMBiosMemoryDevice]s
+    /// Load/Handle pairs defining the [super::SMBiosMemoryDevice]s
     /// associated with this memory channel.
     pub fn load_handle_pairs_iterator(&self) -> LoadHandlePairIterator<'_> {
         LoadHandlePairIterator::new(self)
@@ -192,14 +192,14 @@ impl<'a> LoadHandlePair<'a> {
         }
     }
 
-    /// Channel load provided by the [SMBiosMemoryDevice] associated with this channel
+    /// Channel load provided by the [super::SMBiosMemoryDevice] associated with this channel
     pub fn load(&self) -> Option<u8> {
         self.memory_channel
             .parts()
             .get_field_byte(self.entry_offset)
     }
 
-    /// Structure handle that identifies the [SMBiosMemoryDevice] associated with this channel
+    /// Structure handle that identifies the [super::SMBiosMemoryDevice] associated with this channel
     pub fn handle(&self) -> Option<Handle> {
         self.memory_channel
             .parts()

--- a/src/structs/types/memory_device.rs
+++ b/src/structs/types/memory_device.rs
@@ -6,7 +6,7 @@ use std::ops::Deref;
 
 /// # Memory Device (Type 17)
 ///
-/// This structure describes a single memory device that is part of a larger [SMBiosPhysicalMemoryArray] (Type 16) structure.
+/// This structure describes a single memory device that is part of a larger [super::SMBiosPhysicalMemoryArray] (Type 16) structure.
 ///
 /// Compliant with:
 /// DMTF SMBIOS Reference Specification 3.4.0 (DSP0134)
@@ -29,7 +29,7 @@ impl<'a> SMBiosStruct<'a> for SMBiosMemoryDevice<'a> {
 
 impl<'a> SMBiosMemoryDevice<'a> {
     /// Handle, or instance number, associated with the
-    /// [SMBiosPhysicalMemoryArray] to which this device belongs
+    /// [super::SMBiosPhysicalMemoryArray] to which this device belongs
     pub fn physical_memory_array_handle(&self) -> Option<Handle> {
         self.parts.get_field_handle(0x04)
     }
@@ -40,8 +40,8 @@ impl<'a> SMBiosMemoryDevice<'a> {
     /// structure, the field contains FFFEh; otherwise, the
     /// field contains either FFFFh (if no error was
     /// detected) or the handle of the error-information
-    /// structure ([SMBiosMemoryErrorInformation32] or
-    /// [SMBiosMemoryErrorInformation64]).
+    /// structure ([super::SMBiosMemoryErrorInformation32] or
+    /// [super::SMBiosMemoryErrorInformation64]).
     pub fn memory_error_information_handle(&self) -> Option<Handle> {
         self.parts.get_field_handle(0x06)
     }

--- a/src/structs/types/memory_device_mapped_address.rs
+++ b/src/structs/types/memory_device_mapped_address.rs
@@ -28,7 +28,7 @@ impl<'a> SMBiosStruct<'a> for SMBiosMemoryDeviceMappedAddress<'a> {
 
 impl<'a> SMBiosMemoryDeviceMappedAddress<'a> {
     /// Physical address, in kilobytes, of a range of
-    /// memory mapped to the referenced [SMBiosMemoryDevice]
+    /// memory mapped to the referenced [super::SMBiosMemoryDevice]
     /// When the field value is FFFF FFFFh the actual
     /// address is stored in the Extended Starting
     /// Address field. When this field contains a valid
@@ -42,7 +42,7 @@ impl<'a> SMBiosMemoryDeviceMappedAddress<'a> {
 
     /// Physical ending address of the last kilobyte of a
     /// range of addresses mapped to the referenced
-    /// [SMBiosMemoryDevice]
+    /// [super::SMBiosMemoryDevice]
     /// When the field value is FFFF FFFFh the actual
     /// address is stored in the Extended Ending Address
     /// field. When this field contains a valid address,
@@ -53,10 +53,10 @@ impl<'a> SMBiosMemoryDeviceMappedAddress<'a> {
     }
 
     /// Handle, or instance number, associated with the
-    /// [SMBiosMemoryDevice] structure to which this address
+    /// [super::SMBiosMemoryDevice] structure to which this address
     /// range is mapped
     /// Multiple address ranges can be mapped to a
-    /// single [SMBiosMemoryDevice]
+    /// single [super::SMBiosMemoryDevice]
     pub fn memory_device_handle(&self) -> Option<Handle> {
         self.parts.get_field_handle(0xC)
     }
@@ -65,12 +65,12 @@ impl<'a> SMBiosMemoryDeviceMappedAddress<'a> {
     /// Memory Array Mapped Address structure to which
     /// this device address range is mapped
     /// Multiple address ranges can be mapped to a
-    /// single [SMBiosMemoryArrayMappedAddress].
+    /// single [super::SMBiosMemoryArrayMappedAddress].
     pub fn memory_array_mapped_address_handle(&self) -> Option<Handle> {
         self.parts.get_field_handle(0xE)
     }
 
-    /// Position of the referenced [SMBiosMemoryDevice] in a row
+    /// Position of the referenced [super::SMBiosMemoryDevice] in a row
     /// of the address partition
     /// For example, if two 8-bit devices form a 16-bit row,
     /// this field’s value is either 1 or 2.
@@ -80,7 +80,7 @@ impl<'a> SMBiosMemoryDeviceMappedAddress<'a> {
         self.parts.get_field_byte(0x10)
     }
 
-    /// Position of the referenced [SMBiosMemoryDevice] in an
+    /// Position of the referenced [super::SMBiosMemoryDevice] in an
     /// interleave
     /// The value 0 indicates non-interleaved, 1 indicates
     /// first interleave position, 2 the second interleave
@@ -94,7 +94,7 @@ impl<'a> SMBiosMemoryDeviceMappedAddress<'a> {
     }
 
     /// Maximum number of consecutive rows from the
-    /// referenced [SMBiosMemoryDevice] that are accessed in a
+    /// referenced [super::SMBiosMemoryDevice] that are accessed in a
     /// single interleaved transfer
     /// If the device is not part of an interleave, the field
     /// contains 0; if the interleave configuration is
@@ -108,7 +108,7 @@ impl<'a> SMBiosMemoryDeviceMappedAddress<'a> {
     }
 
     /// Physical address, in bytes, of a range of memory
-    /// mapped to the referenced [SMBiosMemoryDevice]
+    /// mapped to the referenced [super::SMBiosMemoryDevice]
     /// This field is valid when Starting Address contains
     /// the value FFFF FFFFh. If Starting Address
     /// contains a value other than FFFF FFFFh, this field
@@ -121,7 +121,7 @@ impl<'a> SMBiosMemoryDeviceMappedAddress<'a> {
 
     /// Physical ending address, in bytes, of the last of a
     /// range of addresses mapped to the referenced
-    /// [SMBiosMemoryDevice]
+    /// [super::SMBiosMemoryDevice]
     /// This field is valid when both Starting Address and
     /// Ending Address contain the value FFFF FFFFh. If
     /// Ending Address contains a value other than FFFF

--- a/src/structs/types/memory_error_information_32.rs
+++ b/src/structs/types/memory_error_information_32.rs
@@ -5,7 +5,7 @@ use std::ops::Deref;
 
 /// # 32-Bit Memory Error Information (Type 18)
 ///
-/// This structure identifies the specifics of an error that might be detected within a [SMBiosPhysicalMemoryArray].
+/// This structure identifies the specifics of an error that might be detected within a [super::SMBiosPhysicalMemoryArray].
 ///
 /// Compliant with:
 /// DMTF SMBIOS Reference Specification 3.4.0 (DSP0134)

--- a/src/structs/types/memory_error_information_64.rs
+++ b/src/structs/types/memory_error_information_64.rs
@@ -7,7 +7,7 @@ use std::fmt;
 
 /// # 64-Bit Memory Error Information (Type 33)
 ///
-/// This structure describes an error within a [SMBiosPhysicalMemoryArray], when the error address is above 4G (0xFFFFFFFF).
+/// This structure describes an error within a [super::SMBiosPhysicalMemoryArray], when the error address is above 4G (0xFFFFFFFF).
 ///
 /// Compliant with:
 /// DMTF SMBIOS Reference Specification 3.4.0 (DSP0134)

--- a/src/structs/types/on_board_device_information.rs
+++ b/src/structs/types/on_board_device_information.rs
@@ -8,7 +8,7 @@ use std::fmt;
 /// (soldered onto) a system element, usually the baseboard. In general, an entry in this table implies that the
 /// BIOS has some level of control over the enabling of the associated device for use by the system.
 ///
-/// NOTE This structure is obsolete starting with version 2.6 of this specification; the [SMBiosOnboardDevicesExtendedInformation]
+/// NOTE This structure is obsolete starting with version 2.6 of this specification; the [super::SMBiosOnboardDevicesExtendedInformation]
 /// (Type 41) structure should be used instead. BIOS providers can choose to implement
 /// both types to allow existing SMBIOS browsers to properly display the system’s onboard devices information.
 ///

--- a/src/structs/types/physical_memory_array.rs
+++ b/src/structs/types/physical_memory_array.rs
@@ -72,11 +72,11 @@ impl<'a> SMBiosPhysicalMemoryArray<'a> {
         self.parts.get_field_word(0x0B)
     }
 
-    /// Number of slots or sockets available for [SMBiosMemoryDevice]s in this array
+    /// Number of slots or sockets available for [super::SMBiosMemoryDevice]s in this array
     ///
-    /// This value represents the number of [SMBiosMemoryDevice]
+    /// This value represents the number of [super::SMBiosMemoryDevice]
     /// structures that compose this Memory
-    /// Array. Each [SMBiosMemoryDevice] has a reference to
+    /// Array. Each [super::SMBiosMemoryDevice] has a reference to
     /// the "owning" Memory Array.
     pub fn number_of_memory_devices(&self) -> Option<u16> {
         self.parts.get_field_word(0x0D)

--- a/src/structs/types/processor_additional_information.rs
+++ b/src/structs/types/processor_additional_information.rs
@@ -6,7 +6,7 @@ use std::ops::Deref;
 
 /// # Processor Additional Information (Type 44)
 ///
-/// The information in this structure defines the processor additional information in case SMBIOS type 4 [SMBiosProcessorInformation] is
+/// The information in this structure defines the processor additional information in case SMBIOS type 4 [super::SMBiosProcessorInformation] is
 /// not sufficient to describe processor characteristics. The SMBIOS type 44 structure has a reference
 /// handle field to link back to the related SMBIOS type 4 structure. There may be multiple SMBIOS type 44
 /// structures linked to the same SMBIOS type 4 structure. For example, when cores are not identical in a
@@ -40,7 +40,7 @@ impl<'a> SMBiosProcessorAdditionalInformation<'a> {
     const PROCESSOR_SPECIFIC_BLOCK_OFFSET: usize = 0x06usize;
 
     /// Handle, or instance number, associated with the
-    /// [SMBiosProcessorInformation] structure (SMBIOS type 4) which the
+    /// [super::SMBiosProcessorInformation] structure (SMBIOS type 4) which the
     /// Processor Additional Information structure describes.
     pub fn referenced_handle(&self) -> Option<Handle> {
         self.parts.get_field_handle(0x04)

--- a/src/structs/types/processor_information.rs
+++ b/src/structs/types/processor_information.rs
@@ -136,7 +136,7 @@ impl<'a> SMBiosProcessorInformation<'a> {
             .map(|raw| ProcessorUpgradeData::from(raw))
     }
 
-    /// Handle of a [SMBiosCacheInformation] structure that
+    /// Handle of a [super::SMBiosCacheInformation] structure that
     /// defines the attributes of the primary (Level 1)
     /// cache for this processor
     ///
@@ -149,7 +149,7 @@ impl<'a> SMBiosProcessorInformation<'a> {
         self.parts.get_field_handle(0x1A)
     }
 
-    /// Handle of a [SMBiosCacheInformation] structure that
+    /// Handle of a [super::SMBiosCacheInformation] structure that
     /// defines the attributes of the primary (Level 2)
     /// cache for this processor
     ///
@@ -162,7 +162,7 @@ impl<'a> SMBiosProcessorInformation<'a> {
         self.parts.get_field_handle(0x1C)
     }
 
-    /// Handle of a [SMBiosCacheInformation] structure that
+    /// Handle of a [super::SMBiosCacheInformation] structure that
     /// defines the attributes of the primary (Level 3)
     /// cache for this processor
     ///

--- a/src/structs/types/system_power_supply.rs
+++ b/src/structs/types/system_power_supply.rs
@@ -120,7 +120,7 @@ impl<'a> SMBiosSystemPowerSupply<'a> {
 
     /// Input voltage probe handle
     ///
-    /// Handle, or instance number, of a [SMBiosVoltageProbe] (Type 26)
+    /// Handle, or instance number, of a [super::SMBiosVoltageProbe] (Type 26)
     /// monitoring this power supply's input voltage
     ///
     /// A value of 0xFFFF indicates that no probe is provided
@@ -130,7 +130,7 @@ impl<'a> SMBiosSystemPowerSupply<'a> {
 
     /// Cooling device handle
     ///
-    /// Handle, or instance number, of a [SMBiosCoolingDevice] (Type
+    /// Handle, or instance number, of a [super::SMBiosCoolingDevice] (Type
     /// 27) associated with this power supply
     ///
     /// A value of 0xFFFF indicates that no cooling device is
@@ -141,7 +141,7 @@ impl<'a> SMBiosSystemPowerSupply<'a> {
 
     /// Input current probe handle
     ///
-    /// Handle, or instance number, of the [SMBiosElectricalCurrentProbe]
+    /// Handle, or instance number, of the [super::SMBiosElectricalCurrentProbe]
     /// (Type 29) monitoring this power supply’s input
     /// current
     ///


### PR DESCRIPTION
SystemSlot's Id field is two bytes which are more easy to work with when represented as two individual bytes because depending on the slot type the two bytes are interpreted differently.