### PR TITLE
Add no_std compatibility and x86_64 crate helper

### DIFF
--- a/.github/workflows/smbios_ci.yml
+++ b/.github/workflows/smbios_ci.yml
@@ -22,5 +22,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build
       run: cargo build --verbose
+    - name: Build no-std
+      run: cargo +nightly build --features no_std,x86_64 --lib
     - name: Run tests
       run: cargo test --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/jrgerber/smbios-lib"
 repository = "https://github.com/jrgerber/smbios-lib"
 readme = "README.md"
 keywords = ["bios", "smbios", "dmtf"]
-categories = ["hardware-support"]
+categories = ["hardware-support", "no-std"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -20,11 +20,13 @@ path = "src/lib.rs"
 [[bin]]
 name = "smbiosdump"
 path = "src/main.rs"
+required-features = ["getopts", "serde_json"]
 
 [dependencies]
-getopts = "0.2.21"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1.0"
+getopts = { version = "0.2.21", optional = true }
+serde = { version = "1", features = ["derive"], default-features = false }
+serde_json = { version = "1.0", optional = true }
+x86_64 = { version = "0.14.3", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 libc = "0.2"
@@ -35,3 +37,7 @@ mach = "^0.3"
 core-foundation = "~0.6"
 core-foundation-sys = "~0.6"
 io-kit-sys = "0.1.0"
+
+[features]
+default = ["serde/std", "getopts", "serde_json"]
+no_std = ["serde/alloc"]

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ An SMBIOS Library created in Rust that reads and parses raw BIOS data
 * [Examples](#examples)
 
 ## General info
-This project reads raw [SMBIOS](https://en.wikipedia.org/wiki/BIOS) data from either a device or file and provides the data as an API.
+This project reads raw [SMBIOS](https://en.wikipedia.org/wiki/BIOS) data from either a device, a file or a byte slice and provides the data as an API.
 
 For an example project using this library take a look at [dmidecode-rs](https://github.com/jrgerber/dmidecode-rs).
 
@@ -22,6 +22,7 @@ Specification 3.4.0](https://www.dmtf.org/sites/default/files/standards/document
 * Linux
 * MacOS
 * Windows family
+* No-std environments (for hobby OS development)
 
 > SMBIOS 3.4.0 contains 47 defined structure types, all of which are covered by this library (types 0-44, 126, and 127).  Support via extensibility exists for types 128-255 (reserved for OEMs).  Extensibility also applies in the case when this library has not been updated for the latest specification version or a pre-released specification and a new type is introduced.
 

--- a/src/core/header.rs
+++ b/src/core/header.rs
@@ -1,5 +1,5 @@
 use serde::{ser::SerializeStruct, Serialize, Serializer};
-use std::{convert::TryInto, fmt, ops::Deref, str::FromStr};
+use core::{convert::TryInto, fmt, ops::Deref, str::FromStr, any};
 
 /// # Structure Handle
 ///
@@ -36,7 +36,7 @@ impl Deref for Handle {
 }
 
 impl FromStr for Handle {
-    type Err = std::num::ParseIntError;
+    type Err = core::num::ParseIntError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(Handle(if s.starts_with("0x") && s.len() > 2 {
@@ -65,7 +65,7 @@ impl Deref for SMBiosType {
 
 impl fmt::Debug for SMBiosType {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SMBiosType>())
+        fmt.debug_struct(any::type_name::<SMBiosType>())
             .field("type", &self.0)
             .finish()
     }
@@ -78,7 +78,7 @@ pub struct Header([u8; 4]);
 
 impl fmt::Debug for Header {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<Header>())
+        fmt.debug_struct(any::type_name::<Header>())
             .field("struct_type", &self.struct_type())
             .field("length", &self.length())
             .field("handle", &self.handle())
@@ -143,7 +143,7 @@ impl Header {
     }
 
     /// Byte iterator of the header
-    pub fn iter(&self) -> std::slice::Iter<'_, u8> {
+    pub fn iter(&self) -> core::slice::Iter<'_, u8> {
         self.0.iter()
     }
 }

--- a/src/core/strings.rs
+++ b/src/core/strings.rs
@@ -1,5 +1,6 @@
 use serde::{ser::SerializeSeq, Serialize, Serializer};
-use std::fmt;
+use core::fmt;
+use alloc::{vec::Vec, string::String, vec};
 
 /// # SMBIOS Strings
 ///
@@ -64,7 +65,7 @@ impl Strings {
     }
 
     /// Iterates the raw bytes of the strings. The terminating 0 is not included in each string.
-    pub fn iter(&self) -> std::slice::Iter<'_, Vec<u8>> {
+    pub fn iter(&self) -> core::slice::Iter<'_, Vec<u8>> {
         self.strings.iter()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,26 +7,40 @@
 
 #![warn(missing_docs)]
 #![deny(rust_2018_idioms)]
+#![cfg_attr(feature = "no_std", no_std)]
+
+extern crate alloc;
 
 mod core;
+#[cfg(not(feature = "no_std"))]
 mod file_io;
+#[cfg(not(feature = "no_std"))]
 mod macos;
 mod structs;
+#[cfg(not(feature = "no_std"))]
 mod unix;
+#[cfg(not(feature = "no_std"))]
 mod windows;
+#[cfg(all(feature = "x86_64", feature = "no_std"))]
+mod x86_64;
 
 pub use structs::*;
 
 pub use crate::core::*;
+#[cfg(not(feature = "no_std"))]
 pub use file_io::*;
 
-#[cfg(target_family = "windows")]
+#[cfg(all(target_family = "windows", not(feature = "no_std")))]
 pub use windows::{load_windows_smbios_data, raw_smbios_from_device, table_load_from_device};
 
+#[cfg(not(feature = "no_std"))]
 pub use windows::WinSMBiosData;
 
-#[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
+#[cfg(all(any(target_os = "linux", target_os = "android", target_os = "freebsd"), not(feature = "no_std")))]
 pub use unix::*;
 
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(all(any(target_os = "macos", target_os = "ios"), not(feature = "no_std")))]
 pub use macos::*;
+
+#[cfg(all(feature = "x86_64", feature = "no_std"))]
+pub use crate::x86_64::*;

--- a/src/structs/defined_struct.rs
+++ b/src/structs/defined_struct.rs
@@ -2,7 +2,8 @@
 //! via into() and into_iter() trait functions for [UndefinedStruct].
 
 use serde::Serialize;
-use std::iter::FromIterator;
+use core::iter::FromIterator;
+use alloc::vec::{Vec, IntoIter};
 
 use crate::core::UndefinedStruct;
 
@@ -303,7 +304,7 @@ impl<'a> DefinedStructTable<'a> {
 
 impl<'a> IntoIterator for DefinedStructTable<'a> {
     type Item = DefinedStruct<'a>;
-    type IntoIter = std::vec::IntoIter<Self::Item>;
+    type IntoIter = IntoIter<Self::Item>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()

--- a/src/structs/types/additional_information.rs
+++ b/src/structs/types/additional_information.rs
@@ -1,7 +1,8 @@
 use crate::core::{Handle, UndefinedStruct};
 use crate::structs::SMBiosStruct;
 use serde::{ser::SerializeSeq, ser::SerializeStruct, Serialize, Serializer};
-use std::fmt;
+use core::{fmt, any};
+use alloc::{string::String, vec::Vec};
 
 /// # Additional Information Entry contained within [SMBiosAdditionalInformation]
 pub struct AdditionalInformationEntry<'a> {
@@ -73,7 +74,7 @@ impl<'a> AdditionalInformationEntry<'a> {
 
 impl fmt::Debug for AdditionalInformationEntry<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SMBiosAdditionalInformation<'_>>())
+        fmt.debug_struct(any::type_name::<SMBiosAdditionalInformation<'_>>())
             .field("entry_length", &self.entry_length())
             .field("referenced_handle", &self.referenced_handle())
             .field("referenced_offset", &self.referenced_offset())
@@ -239,7 +240,7 @@ impl<'a> SMBiosAdditionalInformation<'a> {
 
 impl fmt::Debug for SMBiosAdditionalInformation<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SMBiosAdditionalInformation<'_>>())
+        fmt.debug_struct(any::type_name::<SMBiosAdditionalInformation<'_>>())
             .field("header", &self.parts.header)
             .field("number_of_entries", &self.number_of_entries())
             .field("entry_iterator", &self.entry_iterator())

--- a/src/structs/types/baseboard_information.rs
+++ b/src/structs/types/baseboard_information.rs
@@ -1,8 +1,9 @@
 use crate::core::{Handle, UndefinedStruct};
 use crate::SMBiosStruct;
 use serde::{ser::SerializeSeq, ser::SerializeStruct, Serialize, Serializer};
-use std::fmt;
-use std::ops::Deref;
+use core::{fmt, any};
+use core::ops::Deref;
+use alloc::{string::String, vec::Vec};
 
 /// # Baseboard (or Module) Information (Type 2)
 ///
@@ -88,7 +89,7 @@ impl<'a> SMBiosBaseboardInformation<'a> {
 
 impl fmt::Debug for SMBiosBaseboardInformation<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SMBiosBaseboardInformation<'_>>())
+        fmt.debug_struct(any::type_name::<SMBiosBaseboardInformation<'_>>())
             .field("header", &self.parts.header)
             .field("manufacturer", &self.manufacturer())
             .field("product", &self.product())
@@ -154,7 +155,7 @@ pub struct BoardTypeData {
 
 impl fmt::Debug for BoardTypeData {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<BoardTypeData>())
+        fmt.debug_struct(any::type_name::<BoardTypeData>())
             .field("raw", &self.raw)
             .field("value", &self.value)
             .finish()
@@ -302,7 +303,7 @@ impl BaseboardFeatures {
 
 impl fmt::Debug for BaseboardFeatures {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<BaseboardFeatures>())
+        fmt.debug_struct(any::type_name::<BaseboardFeatures>())
             .field("raw", &self.raw)
             .field("hosting_board", &self.hosting_board())
             .field("requires_daughterboard", &self.requires_daughterboard())

--- a/src/structs/types/bios_information.rs
+++ b/src/structs/types/bios_information.rs
@@ -1,7 +1,8 @@
 use crate::{SMBiosStruct, UndefinedStruct};
 use serde::{ser::SerializeStruct, Serialize, Serializer};
-use std::fmt;
-use std::ops::Deref;
+use core::{fmt, any};
+use core::ops::Deref;
+use alloc::string::String;
 
 /// #  BIOS Information (Type 0)
 pub struct SMBiosInformation<'a> {
@@ -229,7 +230,7 @@ impl From<u16> for ExtendedRomSize {
 
 impl fmt::Debug for SMBiosInformation<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SMBiosInformation<'_>>())
+        fmt.debug_struct(any::type_name::<SMBiosInformation<'_>>())
             .field("header", &self.parts.header)
             .field("vendor", &self.vendor())
             .field("version", &self.version())
@@ -499,7 +500,7 @@ impl BiosCharacteristics {
 
 impl fmt::Debug for BiosCharacteristics {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<BiosCharacteristics>())
+        fmt.debug_struct(any::type_name::<BiosCharacteristics>())
             .field("raw", &self.raw)
             .field("unknown", &self.unknown())
             .field(
@@ -707,7 +708,7 @@ impl BiosCharacteristicsExtension0 {
 
 impl fmt::Debug for BiosCharacteristicsExtension0 {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<BiosCharacteristicsExtension0>())
+        fmt.debug_struct(any::type_name::<BiosCharacteristicsExtension0>())
             .field("raw", &self.raw)
             .field("acpi_is_supported", &self.acpi_is_supported())
             .field("usb_legacy_is_supported", &self.usb_legacy_is_supported())
@@ -814,7 +815,7 @@ impl BiosCharacteristicsExtension1 {
 
 impl fmt::Debug for BiosCharacteristicsExtension1 {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<BiosCharacteristicsExtension1>())
+        fmt.debug_struct(any::type_name::<BiosCharacteristicsExtension1>())
             .field("raw", &self.raw)
             .field(
                 "bios_boot_specification_is_supported",

--- a/src/structs/types/bios_language_information.rs
+++ b/src/structs/types/bios_language_information.rs
@@ -1,7 +1,8 @@
 use crate::{SMBiosStruct, Strings, UndefinedStruct};
 use serde::{ser::SerializeStruct, Serialize, Serializer};
-use std::fmt;
-use std::ops::Deref;
+use core::{fmt, any};
+use core::ops::Deref;
+use alloc::string::String;
 
 /// # BIOS Language Information (Type 13)
 ///
@@ -55,7 +56,7 @@ impl<'a> SMBiosBiosLanguageInformation<'a> {
 
 impl fmt::Debug for SMBiosBiosLanguageInformation<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SMBiosBiosLanguageInformation<'_>>())
+        fmt.debug_struct(any::type_name::<SMBiosBiosLanguageInformation<'_>>())
             .field("header", &self.parts.header)
             .field(
                 "number_of_installable_languages",
@@ -133,7 +134,7 @@ impl BiosLanguageFlags {
 
 impl fmt::Debug for BiosLanguageFlags {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<BiosLanguageFlags>())
+        fmt.debug_struct(any::type_name::<BiosLanguageFlags>())
             .field("raw", &self.raw)
             .field("language_format", &self.language_format())
             .finish()

--- a/src/structs/types/bis_entry_point.rs
+++ b/src/structs/types/bis_entry_point.rs
@@ -1,6 +1,6 @@
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use crate::{SMBiosStruct, UndefinedStruct};
-use std::fmt;
+use core::{fmt, any};
 
 // The BIS (Boot Integrity Services) Entry Point structure is not defined in the SMBIOS DMTF document.
 // bisapi037.pdf, section 3.1.3
@@ -97,7 +97,7 @@ impl<'a> SMBiosBisEntryPoint<'a> {
 
 impl fmt::Debug for SMBiosBisEntryPoint<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SMBiosBisEntryPoint<'_>>())
+        fmt.debug_struct(any::type_name::<SMBiosBisEntryPoint<'_>>())
             .field("header", &self.parts.header)
             .field("checksum", &self.checksum())
             .field("bis_entry_16", &self.bis_entry_16())

--- a/src/structs/types/built_in_pointing_device.rs
+++ b/src/structs/types/built_in_pointing_device.rs
@@ -1,7 +1,7 @@
 use crate::{SMBiosStruct, UndefinedStruct};
 use serde::{ser::SerializeStruct, Serialize, Serializer};
-use std::fmt;
-use std::ops::Deref;
+use core::{fmt, any};
+use core::ops::Deref;
 
 /// # Built-in Pointing Device (Type 21)
 ///
@@ -53,7 +53,7 @@ impl<'a> SMBiosBuiltInPointingDevice<'a> {
 
 impl fmt::Debug for SMBiosBuiltInPointingDevice<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SMBiosBuiltInPointingDevice<'_>>())
+        fmt.debug_struct(any::type_name::<SMBiosBuiltInPointingDevice<'_>>())
             .field("header", &self.parts.header)
             .field("device_type", &self.device_type())
             .field("interface", &self.interface())
@@ -91,7 +91,7 @@ pub struct PointingDeviceTypeData {
 
 impl fmt::Debug for PointingDeviceTypeData {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<PointingDeviceTypeData>())
+        fmt.debug_struct(any::type_name::<PointingDeviceTypeData>())
             .field("raw", &self.raw)
             .field("value", &self.value)
             .finish()
@@ -187,7 +187,7 @@ pub struct PointingDeviceInterfaceData {
 
 impl fmt::Debug for PointingDeviceInterfaceData {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<PointingDeviceInterfaceData>())
+        fmt.debug_struct(any::type_name::<PointingDeviceInterfaceData>())
             .field("raw", &self.raw)
             .field("value", &self.value)
             .finish()

--- a/src/structs/types/cache_information.rs
+++ b/src/structs/types/cache_information.rs
@@ -1,7 +1,8 @@
 use crate::{SMBiosStruct, UndefinedStruct};
 use serde::{ser::SerializeStruct, Serialize, Serializer};
-use std::fmt;
-use std::ops::Deref;
+use core::{fmt, any};
+use core::ops::Deref;
+use alloc::string::String;
 
 /// # Cache Information (Type 7)
 ///
@@ -106,7 +107,7 @@ impl<'a> SMBiosCacheInformation<'a> {
 
 impl fmt::Debug for SMBiosCacheInformation<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SMBiosCacheInformation<'_>>())
+        fmt.debug_struct(any::type_name::<SMBiosCacheInformation<'_>>())
             .field("header", &self.parts.header)
             .field("socket_designation", &self.socket_designation())
             .field("cache_configuration", &self.cache_configuration())
@@ -162,7 +163,7 @@ pub struct CacheAssociativityData {
 
 impl fmt::Debug for CacheAssociativityData {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<CacheAssociativityData>())
+        fmt.debug_struct(any::type_name::<CacheAssociativityData>())
             .field("raw", &self.raw)
             .field("value", &self.value)
             .finish()
@@ -264,7 +265,7 @@ pub struct SystemCacheTypeData {
 
 impl fmt::Debug for SystemCacheTypeData {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SystemCacheTypeData>())
+        fmt.debug_struct(any::type_name::<SystemCacheTypeData>())
             .field("raw", &self.raw)
             .field("value", &self.value)
             .finish()
@@ -348,7 +349,7 @@ pub struct ErrorCorrectionTypeData {
 
 impl fmt::Debug for ErrorCorrectionTypeData {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<ErrorCorrectionTypeData>())
+        fmt.debug_struct(any::type_name::<ErrorCorrectionTypeData>())
             .field("raw", &self.raw)
             .field("value", &self.value)
             .finish()
@@ -480,7 +481,7 @@ impl SramTypes {
 
 impl fmt::Debug for SramTypes {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SramTypes>())
+        fmt.debug_struct(any::type_name::<SramTypes>())
             .field("raw", &self.raw)
             .field("other", &self.other())
             .field("unknown", &self.unknown())
@@ -593,7 +594,7 @@ impl CacheConfiguaration {
 
 impl fmt::Debug for CacheConfiguaration {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<CacheConfiguaration>())
+        fmt.debug_struct(any::type_name::<CacheConfiguaration>())
             .field("raw", &self.raw)
             .field("cache_level", &self.cache_level())
             .field("cache_socketed", &self.cache_socketed())

--- a/src/structs/types/cooling_device.rs
+++ b/src/structs/types/cooling_device.rs
@@ -1,7 +1,8 @@
 use crate::core::{Handle, UndefinedStruct};
 use crate::SMBiosStruct;
 use serde::{ser::SerializeStruct, Serialize, Serializer};
-use std::fmt;
+use core::{fmt, any};
+use alloc::string::String;
 
 /// # Cooling Device (Type 27)
 ///
@@ -98,7 +99,7 @@ impl From<u16> for RotationalSpeed {
 
 impl fmt::Debug for SMBiosCoolingDevice<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SMBiosCoolingDevice<'_>>())
+        fmt.debug_struct(any::type_name::<SMBiosCoolingDevice<'_>>())
             .field("header", &self.parts.header)
             .field("temperature_probe_handle", &self.temperature_probe_handle())
             .field("device_type_and_status", &self.device_type_and_status())
@@ -145,7 +146,7 @@ pub struct CoolingDeviceTypeAndStatus {
 
 impl fmt::Debug for CoolingDeviceTypeAndStatus {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<CoolingDeviceTypeAndStatus>())
+        fmt.debug_struct(any::type_name::<CoolingDeviceTypeAndStatus>())
             .field("raw", &self.raw)
             .field("device_status", &self.device_status)
             .field("device_type", &self.device_type)

--- a/src/structs/types/electrical_current_probe.rs
+++ b/src/structs/types/electrical_current_probe.rs
@@ -1,6 +1,7 @@
 use crate::{SMBiosStruct, UndefinedStruct};
 use serde::{ser::SerializeStruct, Serialize, Serializer};
-use std::fmt;
+use core::{fmt, any};
+use alloc::string::String;
 
 /// # Electrical Current Probe (Type 29)
 ///
@@ -88,7 +89,7 @@ impl<'a> SMBiosElectricalCurrentProbe<'a> {
 
 impl fmt::Debug for SMBiosElectricalCurrentProbe<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SMBiosElectricalCurrentProbe<'_>>())
+        fmt.debug_struct(any::type_name::<SMBiosElectricalCurrentProbe<'_>>())
             .field("header", &self.parts.header)
             .field("description", &self.description())
             .field("location_and_status", &self.location_and_status())
@@ -141,7 +142,7 @@ pub struct CurrentProbeLocationAndStatus {
 
 impl fmt::Debug for CurrentProbeLocationAndStatus {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<CurrentProbeLocationAndStatus>())
+        fmt.debug_struct(any::type_name::<CurrentProbeLocationAndStatus>())
             .field("raw", &self.raw)
             .field("status", &self.status)
             .field("location", &self.location)

--- a/src/structs/types/end_of_table.rs
+++ b/src/structs/types/end_of_table.rs
@@ -1,6 +1,6 @@
 use crate::{SMBiosStruct, UndefinedStruct};
 use serde::{ser::SerializeStruct, Serialize, Serializer};
-use std::fmt;
+use core::{fmt, any};
 
 /// # End-of-Table (Type 127)
 ///
@@ -35,7 +35,7 @@ impl<'a> SMBiosEndOfTable<'a> {}
 
 impl fmt::Debug for SMBiosEndOfTable<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SMBiosEndOfTable<'_>>())
+        fmt.debug_struct(any::type_name::<SMBiosEndOfTable<'_>>())
             .field("header", &self.parts.header)
             .finish()
     }

--- a/src/structs/types/group_associations.rs
+++ b/src/structs/types/group_associations.rs
@@ -1,7 +1,8 @@
 use crate::core::{Handle, UndefinedStruct};
 use crate::SMBiosStruct;
 use serde::{ser::SerializeSeq, ser::SerializeStruct, Serialize, Serializer};
-use std::fmt;
+use core::{fmt, any};
+use alloc::{string::String, vec::Vec};
 
 /// # Group Associations (Type 14)
 ///
@@ -59,7 +60,7 @@ impl<'a> SMBiosGroupAssociations<'a> {
 
 impl fmt::Debug for SMBiosGroupAssociations<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SMBiosGroupAssociations<'_>>())
+        fmt.debug_struct(any::type_name::<SMBiosGroupAssociations<'_>>())
             .field("header", &self.parts.header)
             .field("group_name", &self.group_name())
             .field("number_of_items", &self.number_of_items())
@@ -120,7 +121,7 @@ impl<'a> GroupAssociationItem<'a> {
 
 impl fmt::Debug for GroupAssociationItem<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<GroupAssociationItem<'_>>())
+        fmt.debug_struct(any::type_name::<GroupAssociationItem<'_>>())
             .field("struct_type", &self.struct_type())
             .field("item_handle", &self.item_handle())
             .finish()

--- a/src/structs/types/hardware_security.rs
+++ b/src/structs/types/hardware_security.rs
@@ -1,6 +1,6 @@
 use crate::{SMBiosStruct, UndefinedStruct};
 use serde::{ser::SerializeStruct, Serialize, Serializer};
-use std::fmt;
+use core::{fmt, any};
 
 /// # Hardware Security (Type 24)
 ///
@@ -36,7 +36,7 @@ impl<'a> SMBiosHardwareSecurity<'a> {
 
 impl fmt::Debug for SMBiosHardwareSecurity<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SMBiosHardwareSecurity<'_>>())
+        fmt.debug_struct(any::type_name::<SMBiosHardwareSecurity<'_>>())
             .field("header", &self.parts.header)
             .field(
                 "hardware_security_settings",
@@ -78,7 +78,7 @@ pub struct HardwareSecuritySettings {
 
 impl fmt::Debug for HardwareSecuritySettings {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<HardwareSecuritySettings>())
+        fmt.debug_struct(any::type_name::<HardwareSecuritySettings>())
             .field("raw", &self.raw)
             .field("power_on_password_status", &self.power_on_password_status)
             .field("keyboard_password_status", &self.keyboard_password_status)

--- a/src/structs/types/inactive.rs
+++ b/src/structs/types/inactive.rs
@@ -1,6 +1,6 @@
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use crate::{SMBiosStruct, UndefinedStruct};
-use std::fmt;
+use core::{fmt, any};
 
 /// # Inactive (Type 126)
 ///
@@ -31,7 +31,7 @@ impl<'a> SMBiosInactive<'a> {}
 
 impl fmt::Debug for SMBiosInactive<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SMBiosInactive<'_>>())
+        fmt.debug_struct(any::type_name::<SMBiosInactive<'_>>())
             .field("header", &self.parts.header)
             .finish()
     }

--- a/src/structs/types/ipmi_device_information.rs
+++ b/src/structs/types/ipmi_device_information.rs
@@ -1,7 +1,7 @@
 use crate::{SMBiosStruct, UndefinedStruct};
 use serde::{ser::SerializeStruct, Serialize, Serializer};
-use std::fmt;
-use std::ops::Deref;
+use core::{fmt, any};
+use core::ops::Deref;
 
 /// # IPMI Device Information (Type 38)
 ///
@@ -78,7 +78,7 @@ impl<'a> SMBiosIpmiDeviceInformation<'a> {
 
 impl fmt::Debug for SMBiosIpmiDeviceInformation<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SMBiosIpmiDeviceInformation<'_>>())
+        fmt.debug_struct(any::type_name::<SMBiosIpmiDeviceInformation<'_>>())
             .field("header", &self.parts.header)
             .field("interface_type", &self.interface_type())
             .field(
@@ -137,7 +137,7 @@ pub struct BaseAddressModifier {
 
 impl fmt::Debug for BaseAddressModifier {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<BaseAddressModifier>())
+        fmt.debug_struct(any::type_name::<BaseAddressModifier>())
             .field("raw", &self.raw)
             .field("register_spacing", &self.register_spacing)
             .field("ls_address_bit", &self.ls_address_bit)
@@ -282,7 +282,7 @@ pub struct IpmiInterfaceTypeData {
 
 impl fmt::Debug for IpmiInterfaceTypeData {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<IpmiInterfaceType>())
+        fmt.debug_struct(any::type_name::<IpmiInterfaceType>())
             .field("raw", &self.raw)
             .field("value", &self.value)
             .finish()

--- a/src/structs/types/management_controller_host_interface.rs
+++ b/src/structs/types/management_controller_host_interface.rs
@@ -1,7 +1,8 @@
 use crate::{SMBiosStruct, UndefinedStruct};
 use serde::{ser::SerializeSeq, ser::SerializeStruct, Serialize, Serializer};
-use std::fmt;
-use std::ops::Deref;
+use core::{fmt, any};
+use core::ops::Deref;
+use alloc::vec::Vec;
 
 /// # Management Controller Host Interface (Type 42)
 ///
@@ -93,7 +94,7 @@ impl<'a> SMBiosManagementControllerHostInterface<'a> {
 
 impl fmt::Debug for SMBiosManagementControllerHostInterface<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<
+        fmt.debug_struct(any::type_name::<
             SMBiosManagementControllerHostInterface<'_>,
         >())
         .field("header", &self.parts.header)
@@ -192,7 +193,7 @@ pub struct HostInterfaceTypeData {
 
 impl fmt::Debug for HostInterfaceTypeData {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<HostInterfaceType>())
+        fmt.debug_struct(any::type_name::<HostInterfaceType>())
             .field("raw", &self.raw)
             .field("value", &self.value)
             .finish()
@@ -311,7 +312,7 @@ impl From<u8> for HostProtocolTypeData {
 
 impl fmt::Debug for HostProtocolTypeData {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<HostProtocolTypeData>())
+        fmt.debug_struct(any::type_name::<HostProtocolTypeData>())
             .field("raw", &self.raw)
             .field("value", &self.value)
             .finish()
@@ -396,7 +397,7 @@ impl<'a> ProtocolRecord<'a> {
 
 impl fmt::Debug for ProtocolRecord<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<ProtocolRecord<'_>>())
+        fmt.debug_struct(any::type_name::<ProtocolRecord<'_>>())
             .field("protocol_type", &self.protocol_type())
             .field(
                 "protocol_type_specific_data_length",

--- a/src/structs/types/management_device.rs
+++ b/src/structs/types/management_device.rs
@@ -1,7 +1,8 @@
 use crate::{SMBiosStruct, UndefinedStruct};
 use serde::{ser::SerializeStruct, Serialize, Serializer};
-use std::fmt;
-use std::ops::Deref;
+use core::{fmt, any};
+use core::ops::Deref;
+use alloc::string::String;
 
 /// # Management Device (Type 34)
 ///
@@ -54,7 +55,7 @@ impl<'a> SMBiosManagementDevice<'a> {
 
 impl fmt::Debug for SMBiosManagementDevice<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SMBiosManagementDevice<'_>>())
+        fmt.debug_struct(any::type_name::<SMBiosManagementDevice<'_>>())
             .field("header", &self.parts.header)
             .field("description", &self.description())
             .field("device_type", &self.device_type())
@@ -94,7 +95,7 @@ pub struct ManagementDeviceTypeData {
 
 impl fmt::Debug for ManagementDeviceTypeData {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<ManagementDeviceTypeData>())
+        fmt.debug_struct(any::type_name::<ManagementDeviceTypeData>())
             .field("raw", &self.raw)
             .field("value", &self.value)
             .finish()
@@ -202,7 +203,7 @@ pub struct ManagementDeviceAddressTypeData {
 
 impl fmt::Debug for ManagementDeviceAddressTypeData {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<ManagementDeviceAddressTypeData>())
+        fmt.debug_struct(any::type_name::<ManagementDeviceAddressTypeData>())
             .field("raw", &self.raw)
             .field("value", &self.value)
             .finish()

--- a/src/structs/types/management_device_component.rs
+++ b/src/structs/types/management_device_component.rs
@@ -1,7 +1,8 @@
 use crate::core::{Handle, UndefinedStruct};
 use crate::SMBiosStruct;
 use serde::{ser::SerializeStruct, Serialize, Serializer};
-use std::fmt;
+use core::{fmt, any};
+use alloc::string::String;
 
 /// # Management Device Component (Type 35)
 ///
@@ -54,7 +55,7 @@ impl<'a> SMBiosManagementDeviceComponent<'a> {
 
 impl fmt::Debug for SMBiosManagementDeviceComponent<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SMBiosManagementDeviceComponent<'_>>())
+        fmt.debug_struct(any::type_name::<SMBiosManagementDeviceComponent<'_>>())
             .field("header", &self.parts.header)
             .field("description", &self.description())
             .field("management_device_handle", &self.management_device_handle())

--- a/src/structs/types/management_device_threshold_data.rs
+++ b/src/structs/types/management_device_threshold_data.rs
@@ -1,6 +1,6 @@
 use crate::{SMBiosStruct, UndefinedStruct};
 use serde::{ser::SerializeStruct, Serialize, Serializer};
-use std::fmt;
+use core::{fmt, any};
 
 /// # Management Device Threshold Data (Type 36)
 ///
@@ -65,7 +65,7 @@ impl<'a> SMBiosManagementDeviceThresholdData<'a> {
 
 impl fmt::Debug for SMBiosManagementDeviceThresholdData<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SMBiosManagementDeviceThresholdData<'_>>())
+        fmt.debug_struct(any::type_name::<SMBiosManagementDeviceThresholdData<'_>>())
             .field("header", &self.parts.header)
             .field(
                 "lower_threshold_non_critical",

--- a/src/structs/types/memory_array_mapped_address.rs
+++ b/src/structs/types/memory_array_mapped_address.rs
@@ -1,7 +1,7 @@
 use crate::core::{Handle, UndefinedStruct};
 use crate::SMBiosStruct;
 use serde::{ser::SerializeStruct, Serialize, Serializer};
-use std::fmt;
+use core::{fmt, any};
 
 /// # Memory Array Mapped Address (Type 19)
 ///
@@ -99,7 +99,7 @@ impl<'a> SMBiosMemoryArrayMappedAddress<'a> {
 
 impl fmt::Debug for SMBiosMemoryArrayMappedAddress<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SMBiosMemoryArrayMappedAddress<'_>>())
+        fmt.debug_struct(any::type_name::<SMBiosMemoryArrayMappedAddress<'_>>())
             .field("header", &self.parts.header)
             .field("starting_address", &self.starting_address())
             .field("ending_address", &self.ending_address())

--- a/src/structs/types/memory_channel.rs
+++ b/src/structs/types/memory_channel.rs
@@ -1,8 +1,9 @@
 use crate::core::{Handle, UndefinedStruct};
 use crate::SMBiosStruct;
 use serde::{ser::SerializeSeq, ser::SerializeStruct, Serialize, Serializer};
-use std::fmt;
-use std::ops::Deref;
+use core::{fmt, any};
+use core::ops::Deref;
+use alloc::vec::Vec;
 
 /// # Memory Channel (Type 37)
 ///
@@ -63,7 +64,7 @@ impl<'a> SMBiosMemoryChannel<'a> {
 
 impl fmt::Debug for SMBiosMemoryChannel<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SMBiosMemoryChannel<'_>>())
+        fmt.debug_struct(any::type_name::<SMBiosMemoryChannel<'_>>())
             .field("header", &self.parts.header)
             .field("channel_type", &self.channel_type())
             .field("maximum_channel_load", &self.maximum_channel_load())
@@ -109,7 +110,7 @@ pub struct MemoryChannelTypeData {
 
 impl fmt::Debug for MemoryChannelTypeData {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<MemoryChannelTypeData>())
+        fmt.debug_struct(any::type_name::<MemoryChannelTypeData>())
             .field("raw", &self.raw)
             .field("value", &self.value)
             .finish()
@@ -209,7 +210,7 @@ impl<'a> LoadHandlePair<'a> {
 
 impl fmt::Debug for LoadHandlePair<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<LoadHandlePair<'_>>())
+        fmt.debug_struct(any::type_name::<LoadHandlePair<'_>>())
             .field("load", &self.load())
             .field("handle", &self.handle())
             .finish()

--- a/src/structs/types/memory_controller_information.rs
+++ b/src/structs/types/memory_controller_information.rs
@@ -1,8 +1,9 @@
 use crate::core::{Handle, UndefinedStruct};
 use crate::SMBiosStruct;
 use serde::{ser::SerializeSeq, ser::SerializeStruct, Serialize, Serializer};
-use std::fmt;
-use std::ops::Deref;
+use core::{fmt, any};
+use core::ops::Deref;
+use alloc::vec::Vec;
 
 /// # Memory Controller Information (Type 5, Obsolete)
 ///
@@ -108,7 +109,7 @@ impl<'a> SMBiosMemoryControllerInformation<'a> {
 
 impl fmt::Debug for SMBiosMemoryControllerInformation<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SMBiosMemoryControllerInformation<'_>>())
+        fmt.debug_struct(any::type_name::<SMBiosMemoryControllerInformation<'_>>())
             .field("header", &self.parts.header)
             .field("error_detecting_method", &self.error_detecting_method())
             .field(
@@ -192,7 +193,7 @@ pub struct ErrorDetectingMethodData {
 
 impl fmt::Debug for ErrorDetectingMethodData {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<ErrorDetectingMethodData>())
+        fmt.debug_struct(any::type_name::<ErrorDetectingMethodData>())
             .field("raw", &self.raw)
             .field("value", &self.value)
             .finish()
@@ -319,7 +320,7 @@ impl ErrorCorrectingCapabilities {
 
 impl fmt::Debug for ErrorCorrectingCapabilities {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<ErrorCorrectingCapabilities>())
+        fmt.debug_struct(any::type_name::<ErrorCorrectingCapabilities>())
             .field("raw", &self.raw)
             .field("other", &self.other())
             .field("unknown", &self.unknown())
@@ -375,7 +376,7 @@ pub struct InterleaveSupportData {
 
 impl fmt::Debug for InterleaveSupportData {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<InterleaveSupportData>())
+        fmt.debug_struct(any::type_name::<InterleaveSupportData>())
             .field("raw", &self.raw)
             .field("value", &self.value)
             .finish()
@@ -491,7 +492,7 @@ impl MemorySpeeds {
 
 impl fmt::Debug for MemorySpeeds {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<MemorySpeeds>())
+        fmt.debug_struct(any::type_name::<MemorySpeeds>())
             .field("raw", &self.raw)
             .field("other", &self.other())
             .field("unknown", &self.unknown())
@@ -598,7 +599,7 @@ impl MemoryTypes {
 
 impl fmt::Debug for MemoryTypes {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<MemoryTypes>())
+        fmt.debug_struct(any::type_name::<MemoryTypes>())
             .field("raw", &self.raw)
             .field("other", &self.other())
             .field("unknown", &self.unknown())
@@ -677,7 +678,7 @@ impl ModuleVoltage {
 
 impl fmt::Debug for ModuleVoltage {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<ModuleVoltage>())
+        fmt.debug_struct(any::type_name::<ModuleVoltage>())
             .field("raw", &self.raw)
             .field("volts_5", &self.volts_5())
             .field("volts_3_3", &self.volts_3_3())

--- a/src/structs/types/memory_device.rs
+++ b/src/structs/types/memory_device.rs
@@ -1,8 +1,9 @@
 use crate::core::{Handle, UndefinedStruct};
 use crate::SMBiosStruct;
 use serde::{ser::SerializeStruct, Serialize, Serializer};
-use std::fmt;
-use std::ops::Deref;
+use core::{fmt, any};
+use core::ops::Deref;
+use alloc::string::String;
 
 /// # Memory Device (Type 17)
 ///
@@ -315,7 +316,7 @@ impl<'a> SMBiosMemoryDevice<'a> {
 
 impl fmt::Debug for SMBiosMemoryDevice<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SMBiosMemoryDevice<'_>>())
+        fmt.debug_struct(any::type_name::<SMBiosMemoryDevice<'_>>())
             .field("header", &self.parts.header)
             .field(
                 "physical_memory_array_handle",
@@ -454,7 +455,7 @@ pub struct MemoryDeviceTypeData {
 
 impl fmt::Debug for MemoryDeviceTypeData {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<MemoryDeviceTypeData>())
+        fmt.debug_struct(any::type_name::<MemoryDeviceTypeData>())
             .field("raw", &self.raw)
             .field("value", &self.value)
             .finish()
@@ -619,7 +620,7 @@ pub struct MemoryFormFactorData {
 
 impl fmt::Debug for MemoryFormFactorData {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<MemoryFormFactorData>())
+        fmt.debug_struct(any::type_name::<MemoryFormFactorData>())
             .field("raw", &self.raw)
             .field("value", &self.value)
             .finish()
@@ -812,7 +813,7 @@ impl MemoryTypeDetails {
 
 impl fmt::Debug for MemoryTypeDetails {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<MemoryTypeDetails>())
+        fmt.debug_struct(any::type_name::<MemoryTypeDetails>())
             .field("raw", &self.raw)
             .field("other", &self.other())
             .field("unknown", &self.unknown())
@@ -874,7 +875,7 @@ pub struct MemoryDeviceTechnologyData {
 
 impl fmt::Debug for MemoryDeviceTechnologyData {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<MemoryDeviceTechnologyData>())
+        fmt.debug_struct(any::type_name::<MemoryDeviceTechnologyData>())
             .field("raw", &self.raw)
             .field("value", &self.value)
             .finish()
@@ -990,7 +991,7 @@ impl MemoryOperatingModeCapabilities {
 
 impl fmt::Debug for MemoryOperatingModeCapabilities {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<MemoryOperatingModeCapabilities>())
+        fmt.debug_struct(any::type_name::<MemoryOperatingModeCapabilities>())
             .field("raw", &self.raw)
             .field("other", &self.other())
             .field("unknown", &self.unknown())

--- a/src/structs/types/memory_device_mapped_address.rs
+++ b/src/structs/types/memory_device_mapped_address.rs
@@ -1,7 +1,7 @@
 use crate::core::{Handle, UndefinedStruct};
 use crate::SMBiosStruct;
 use serde::{ser::SerializeStruct, Serialize, Serializer};
-use std::fmt;
+use core::{fmt, any};
 
 /// # Memory Device Mapped Address (Type 20)
 ///
@@ -135,7 +135,7 @@ impl<'a> SMBiosMemoryDeviceMappedAddress<'a> {
 
 impl fmt::Debug for SMBiosMemoryDeviceMappedAddress<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SMBiosMemoryDeviceMappedAddress<'_>>())
+        fmt.debug_struct(any::type_name::<SMBiosMemoryDeviceMappedAddress<'_>>())
             .field("header", &self.parts.header)
             .field("starting_address", &self.starting_address())
             .field("ending_address", &self.ending_address())

--- a/src/structs/types/memory_error_information_32.rs
+++ b/src/structs/types/memory_error_information_32.rs
@@ -1,7 +1,7 @@
 use crate::{SMBiosStruct, UndefinedStruct};
 use serde::{ser::SerializeStruct, Serialize, Serializer};
-use std::fmt;
-use std::ops::Deref;
+use core::{fmt, any};
+use core::ops::Deref;
 
 /// # 32-Bit Memory Error Information (Type 18)
 ///
@@ -86,7 +86,7 @@ impl<'a> SMBiosMemoryErrorInformation32<'a> {
 
 impl fmt::Debug for SMBiosMemoryErrorInformation32<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SMBiosMemoryErrorInformation32<'_>>())
+        fmt.debug_struct(any::type_name::<SMBiosMemoryErrorInformation32<'_>>())
             .field("header", &self.parts.header)
             .field("error_type", &self.error_type())
             .field("error_granularity", &self.error_granularity())
@@ -138,7 +138,7 @@ pub struct MemoryErrorTypeData {
 
 impl fmt::Debug for MemoryErrorTypeData {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<MemoryErrorTypeData>())
+        fmt.debug_struct(any::type_name::<MemoryErrorTypeData>())
             .field("raw", &self.raw)
             .field("value", &self.value)
             .finish()
@@ -249,7 +249,7 @@ pub struct MemoryErrorGranularityData {
 
 impl fmt::Debug for MemoryErrorGranularityData {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<MemoryErrorGranularityData>())
+        fmt.debug_struct(any::type_name::<MemoryErrorGranularityData>())
             .field("raw", &self.raw)
             .field("value", &self.value)
             .finish()
@@ -321,7 +321,7 @@ pub struct MemoryErrorOperationData {
 
 impl fmt::Debug for MemoryErrorOperationData {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<MemoryErrorOperationData>())
+        fmt.debug_struct(any::type_name::<MemoryErrorOperationData>())
             .field("raw", &self.raw)
             .field("value", &self.value)
             .finish()

--- a/src/structs/types/memory_error_information_64.rs
+++ b/src/structs/types/memory_error_information_64.rs
@@ -3,7 +3,7 @@ use crate::{
     UndefinedStruct,
 };
 use serde::{ser::SerializeStruct, Serialize, Serializer};
-use std::fmt;
+use core::{fmt, any};
 
 /// # 64-Bit Memory Error Information (Type 33)
 ///
@@ -91,7 +91,7 @@ impl<'a> SMBiosMemoryErrorInformation64<'a> {
 
 impl fmt::Debug for SMBiosMemoryErrorInformation64<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SMBiosMemoryErrorInformation64<'_>>())
+        fmt.debug_struct(any::type_name::<SMBiosMemoryErrorInformation64<'_>>())
             .field("header", &self.parts.header)
             .field("error_type", &self.error_type())
             .field("error_granularity", &self.error_granularity())

--- a/src/structs/types/memory_module_information.rs
+++ b/src/structs/types/memory_module_information.rs
@@ -1,6 +1,8 @@
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use crate::{MemoryTypes, SMBiosStruct, UndefinedStruct};
-use std::fmt;
+use core::{fmt, any};
+#[cfg(feature = "no_std")]
+use alloc::string::String;
 
 /// # Memory Module Information (Type 6, Obsolete)
 ///
@@ -76,7 +78,7 @@ impl<'a> SMBiosMemoryModuleInformation<'a> {
 
 impl fmt::Debug for SMBiosMemoryModuleInformation<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SMBiosMemoryModuleInformation<'_>>())
+        fmt.debug_struct(any::type_name::<SMBiosMemoryModuleInformation<'_>>())
             .field("header", &self.parts.header)
             .field("socket_designation", &self.socket_designation())
             .field("bank_connections", &self.bank_connections())

--- a/src/structs/types/oem_strings.rs
+++ b/src/structs/types/oem_strings.rs
@@ -1,6 +1,6 @@
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use crate::{SMBiosStruct, Strings, UndefinedStruct};
-use std::fmt;
+use core::{fmt, any};
 
 /// # OEM Strings (Type 11)
 ///
@@ -40,7 +40,7 @@ impl<'a> SMBiosOemStrings<'a> {
 
 impl fmt::Debug for SMBiosOemStrings<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SMBiosOemStrings<'_>>())
+        fmt.debug_struct(any::type_name::<SMBiosOemStrings<'_>>())
             .field("header", &self.parts.header)
             .field("count", &self.count())
             .field("oem_strings", &self.oem_strings())

--- a/src/structs/types/on_board_device_information.rs
+++ b/src/structs/types/on_board_device_information.rs
@@ -1,6 +1,7 @@
 use crate::{Header, SMBiosStruct, UndefinedStruct};
 use serde::{ser::SerializeSeq, ser::SerializeStruct, Serialize, Serializer};
-use std::fmt;
+use core::{fmt, any};
+use alloc::{string::String, vec::Vec};
 
 /// # On Board Devices Information (Type 10, Obsolete)
 ///
@@ -47,7 +48,7 @@ impl<'a> SMBiosOnBoardDeviceInformation<'a> {
 
 impl fmt::Debug for SMBiosOnBoardDeviceInformation<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SMBiosOnBoardDeviceInformation<'_>>())
+        fmt.debug_struct(any::type_name::<SMBiosOnBoardDeviceInformation<'_>>())
             .field("header", &self.parts.header)
             .field("number_of_devices", &self.number_of_devices())
             .field("onboard_device_iterator", &self.onboard_device_iterator())
@@ -111,7 +112,7 @@ impl<'a> OnBoardDevice<'a> {
 
 impl fmt::Debug for OnBoardDevice<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<OnBoardDevice<'_>>())
+        fmt.debug_struct(any::type_name::<OnBoardDevice<'_>>())
             .field("device_type", &self.device_type())
             .field("description", &self.description())
             .finish()
@@ -173,7 +174,7 @@ impl From<u8> for OnBoardDeviceType {
 
 impl fmt::Debug for OnBoardDeviceType {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<OnBoardDevice<'_>>())
+        fmt.debug_struct(any::type_name::<OnBoardDevice<'_>>())
             .field("raw", &self.raw)
             .field("type_of_device", &self.type_of_device())
             .field("status", &self.status())

--- a/src/structs/types/onboard_devices_extended_information.rs
+++ b/src/structs/types/onboard_devices_extended_information.rs
@@ -1,7 +1,8 @@
 use super::system_slot::{BusNumber, DeviceFunctionNumber, SegmentGroupNumber};
 use crate::{OnBoardDeviceType, SMBiosStruct, UndefinedStruct};
 use serde::{ser::SerializeStruct, Serialize, Serializer};
-use std::fmt;
+use core::{fmt, any};
+use alloc::string::String;
 
 /// # Onboard Devices Extended Information (Type 41)
 ///
@@ -76,7 +77,7 @@ impl<'a> SMBiosOnboardDevicesExtendedInformation<'a> {
 
 impl fmt::Debug for SMBiosOnboardDevicesExtendedInformation<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<
+        fmt.debug_struct(any::type_name::<
             SMBiosOnboardDevicesExtendedInformation<'_>,
         >())
         .field("header", &self.parts.header)

--- a/src/structs/types/out_of_band_remote_access.rs
+++ b/src/structs/types/out_of_band_remote_access.rs
@@ -1,6 +1,8 @@
 use crate::{SMBiosStruct, UndefinedStruct};
+
 use serde::{ser::SerializeStruct, Serialize, Serializer};
-use std::{fmt, ops::Deref};
+use core::{fmt, ops::Deref, any};
+use alloc::string::String;
 
 /// # Out-of-Band Remote Access (Type 30)
 ///
@@ -88,7 +90,7 @@ impl Connections {
 
 impl fmt::Debug for Connections {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<Connections>())
+        fmt.debug_struct(any::type_name::<Connections>())
             .field("raw", &self.raw)
             .field(
                 "inbound_connection_enabled",
@@ -123,7 +125,7 @@ impl Serialize for Connections {
 
 impl fmt::Debug for SMBiosOutOfBandRemoteAccess<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SMBiosOutOfBandRemoteAccess<'_>>())
+        fmt.debug_struct(any::type_name::<SMBiosOutOfBandRemoteAccess<'_>>())
             .field("header", &self.parts.header)
             .field("manufacturer_name", &self.manufacturer_name())
             .field("connections", &self.connections())

--- a/src/structs/types/physical_memory_array.rs
+++ b/src/structs/types/physical_memory_array.rs
@@ -1,7 +1,7 @@
 use crate::core::{Handle, UndefinedStruct};
 use crate::SMBiosStruct;
 use serde::{ser::SerializeStruct, Serialize, Serializer};
-use std::{fmt, ops::Deref};
+use core::{fmt, ops::Deref, any};
 /// # Physical Memory Array (Type 16)
 ///
 /// This structure describes a collection of memory devices that operate together to form a memory address space.
@@ -97,7 +97,7 @@ impl<'a> SMBiosPhysicalMemoryArray<'a> {
 
 impl fmt::Debug for SMBiosPhysicalMemoryArray<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SMBiosPhysicalMemoryArray<'_>>())
+        fmt.debug_struct(any::type_name::<SMBiosPhysicalMemoryArray<'_>>())
             .field("header", &self.parts.header)
             .field("location", &self.location())
             .field("usage", &self.usage())
@@ -155,7 +155,7 @@ pub struct MemoryArrayLocationData {
 
 impl fmt::Debug for MemoryArrayLocationData {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<MemoryArrayLocationData>())
+        fmt.debug_struct(any::type_name::<MemoryArrayLocationData>())
             .field("raw", &self.raw)
             .field("value", &self.value)
             .finish()
@@ -260,7 +260,7 @@ pub struct MemoryArrayUseData {
 
 impl fmt::Debug for MemoryArrayUseData {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<MemoryArrayUseData>())
+        fmt.debug_struct(any::type_name::<MemoryArrayUseData>())
             .field("raw", &self.raw)
             .field("value", &self.value)
             .finish()
@@ -341,7 +341,7 @@ pub struct MemoryArrayErrorCorrectionData {
 
 impl fmt::Debug for MemoryArrayErrorCorrectionData {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<MemoryArrayErrorCorrectionData>())
+        fmt.debug_struct(any::type_name::<MemoryArrayErrorCorrectionData>())
             .field("raw", &self.raw)
             .field("value", &self.value)
             .finish()

--- a/src/structs/types/port_connector_information.rs
+++ b/src/structs/types/port_connector_information.rs
@@ -1,6 +1,7 @@
 use crate::{SMBiosStruct, UndefinedStruct};
 use serde::{ser::SerializeStruct, Serialize, Serializer};
-use std::{fmt, ops::Deref};
+use core::{fmt, ops::Deref, any};
+use alloc::string::String;
 
 /// # Port Connector Information (Type 8)
 ///
@@ -68,7 +69,7 @@ impl<'a> SMBiosPortConnectorInformation<'a> {
 
 impl fmt::Debug for SMBiosPortConnectorInformation<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SMBiosPortConnectorInformation<'_>>())
+        fmt.debug_struct(any::type_name::<SMBiosPortConnectorInformation<'_>>())
             .field("header", &self.parts.header)
             .field(
                 "internal_reference_designator",
@@ -122,7 +123,7 @@ pub struct PortInformationConnectorTypeData {
 
 impl fmt::Debug for PortInformationConnectorTypeData {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<PortInformationConnectorTypeData>())
+        fmt.debug_struct(any::type_name::<PortInformationConnectorTypeData>())
             .field("raw", &self.raw)
             .field("value", &self.value)
             .finish()
@@ -317,7 +318,7 @@ pub struct PortInformationPortTypeData {
 
 impl fmt::Debug for PortInformationPortTypeData {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<PortInformationPortTypeData>())
+        fmt.debug_struct(any::type_name::<PortInformationPortTypeData>())
             .field("raw", &self.raw)
             .field("value", &self.value)
             .finish()

--- a/src/structs/types/portable_battery.rs
+++ b/src/structs/types/portable_battery.rs
@@ -1,7 +1,8 @@
 use crate::{SMBiosStruct, UndefinedStruct};
 use serde::{ser::SerializeStruct, Serialize, Serializer};
-use std::fmt;
-use std::ops::Deref;
+use core::{fmt, any};
+use core::ops::Deref;
+use alloc::string::String;
 
 /// # Portable Battery (Type 22)
 ///
@@ -166,7 +167,7 @@ impl<'a> SMBiosPortableBattery<'a> {
 
 impl fmt::Debug for SMBiosPortableBattery<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SMBiosPortableBattery<'_>>())
+        fmt.debug_struct(any::type_name::<SMBiosPortableBattery<'_>>())
             .field("header", &self.parts.header)
             .field("location", &self.location())
             .field("manufacturer", &self.manufacturer())
@@ -240,7 +241,7 @@ pub struct PortableBatteryDeviceChemistryData {
 
 impl fmt::Debug for PortableBatteryDeviceChemistryData {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<PortableBatteryDeviceChemistryData>())
+        fmt.debug_struct(any::type_name::<PortableBatteryDeviceChemistryData>())
             .field("raw", &self.raw)
             .field("value", &self.value)
             .finish()

--- a/src/structs/types/processor_additional_information.rs
+++ b/src/structs/types/processor_additional_information.rs
@@ -1,8 +1,8 @@
 use crate::core::{Handle, UndefinedStruct};
 use crate::SMBiosStruct;
 use serde::{ser::SerializeStruct, Serialize, Serializer};
-use std::fmt;
-use std::ops::Deref;
+use core::{fmt, any};
+use core::ops::Deref;
 
 /// # Processor Additional Information (Type 44)
 ///
@@ -54,7 +54,7 @@ impl<'a> SMBiosProcessorAdditionalInformation<'a> {
 
 impl fmt::Debug for SMBiosProcessorAdditionalInformation<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<
+        fmt.debug_struct(any::type_name::<
             SMBiosProcessorAdditionalInformation<'_>,
         >())
         .field("header", &self.parts.header)
@@ -131,7 +131,7 @@ impl<'a> ProcessorSpecificBlock<'a> {
 
 impl fmt::Debug for ProcessorSpecificBlock<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<ProcessorSpecificBlock<'_>>())
+        fmt.debug_struct(any::type_name::<ProcessorSpecificBlock<'_>>())
             .field("block_length", &self.block_length())
             .field("processor_type", &self.processor_type())
             .field("processor_specific_data", &self.processor_specific_data())
@@ -167,7 +167,7 @@ pub struct ProcessorArchitectureTypeData {
 
 impl fmt::Debug for ProcessorArchitectureTypeData {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<ProcessorArchitectureTypeData>())
+        fmt.debug_struct(any::type_name::<ProcessorArchitectureTypeData>())
             .field("raw", &self.raw)
             .field("value", &self.value)
             .finish()

--- a/src/structs/types/processor_information.rs
+++ b/src/structs/types/processor_information.rs
@@ -1,9 +1,10 @@
 use crate::core::{Handle, UndefinedStruct};
 use crate::SMBiosStruct;
 use serde::{ser::SerializeStruct, Serialize, Serializer};
-use std::convert::TryInto;
-use std::fmt;
-use std::ops::Deref;
+use core::convert::TryInto;
+use core::{fmt, any};
+use core::ops::Deref;
+use alloc::{string::String, vec::Vec};
 
 /// # Processor Information (Type 4)
 ///
@@ -289,7 +290,7 @@ impl<'a> SMBiosProcessorInformation<'a> {
 
 impl fmt::Debug for SMBiosProcessorInformation<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SMBiosProcessorInformation<'_>>())
+        fmt.debug_struct(any::type_name::<SMBiosProcessorInformation<'_>>())
             .field("header", &self.parts.header)
             .field("socket_designation", &self.socket_designation())
             .field("processor_type", &self.processor_type())
@@ -379,7 +380,7 @@ pub struct ProcessorTypeData {
 
 impl fmt::Debug for ProcessorTypeData {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<ProcessorTypeData>())
+        fmt.debug_struct(any::type_name::<ProcessorTypeData>())
             .field("raw", &self.raw)
             .field("value", &self.value)
             .finish()
@@ -466,7 +467,7 @@ pub struct ProcessorFamilyData {
 
 impl fmt::Debug for ProcessorFamilyData {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<ProcessorFamilyData>())
+        fmt.debug_struct(any::type_name::<ProcessorFamilyData>())
             .field("raw", &self.raw)
             .field("value", &self.value)
             .finish()
@@ -527,7 +528,7 @@ pub struct ProcessorFamilyData2 {
 
 impl fmt::Debug for ProcessorFamilyData2 {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<ProcessorFamilyData2>())
+        fmt.debug_struct(any::type_name::<ProcessorFamilyData2>())
             .field("raw", &self.raw)
             .field("value", &self.value)
             .finish()
@@ -1247,7 +1248,7 @@ pub struct ProcessorUpgradeData {
 
 impl fmt::Debug for ProcessorUpgradeData {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<ProcessorUpgradeData>())
+        fmt.debug_struct(any::type_name::<ProcessorUpgradeData>())
             .field("raw", &self.raw)
             .field("value", &self.value)
             .finish()
@@ -1548,7 +1549,7 @@ impl ProcessorCharacteristics {
 
 impl fmt::Debug for ProcessorCharacteristics {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<ProcessorCharacteristics>())
+        fmt.debug_struct(any::type_name::<ProcessorCharacteristics>())
             .field("raw", &self.raw)
             .field("unknown", &self.unknown())
             .field("bit_64capable", &self.bit_64capable())
@@ -1668,7 +1669,7 @@ impl ProcessorSupportedVoltages {
 
 impl fmt::Debug for ProcessorSupportedVoltages {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<ProcessorSupportedVoltages>())
+        fmt.debug_struct(any::type_name::<ProcessorSupportedVoltages>())
             .field("raw", &self.raw)
             .field("voltages", &self.voltages().as_slice())
             .finish()
@@ -1778,7 +1779,7 @@ impl ProcessorStatus {
 
 impl fmt::Debug for ProcessorStatus {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<ProcessorStatus>())
+        fmt.debug_struct(any::type_name::<ProcessorStatus>())
             .field("raw", &self.raw)
             .field("socket_populated", &self.socket_populated())
             .field("cpu_status", &self.cpu_status())

--- a/src/structs/types/system_boot_information.rs
+++ b/src/structs/types/system_boot_information.rs
@@ -1,6 +1,6 @@
 use crate::{SMBiosStruct, UndefinedStruct};
 use serde::{ser::SerializeStruct, Serialize, Serializer};
-use std::fmt;
+use core::{fmt, any};
 
 /// # System Boot Information (Type 32)
 ///
@@ -60,7 +60,7 @@ impl<'a> SMBiosSystemBootInformation<'a> {
 
 impl fmt::Debug for SMBiosSystemBootInformation<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SMBiosSystemBootInformation<'_>>())
+        fmt.debug_struct(any::type_name::<SMBiosSystemBootInformation<'_>>())
             .field("header", &self.parts.header)
             .field("boot_status_data", &self.boot_status_data())
             .finish()
@@ -106,7 +106,7 @@ impl<'a> SystemBootStatusData<'a> {
 
 impl fmt::Debug for SystemBootStatusData<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SMBiosSystemBootInformation<'_>>())
+        fmt.debug_struct(any::type_name::<SMBiosSystemBootInformation<'_>>())
             .field("system_boot_status", &self.system_boot_status())
             .finish()
     }

--- a/src/structs/types/system_chassis_information.rs
+++ b/src/structs/types/system_chassis_information.rs
@@ -1,8 +1,9 @@
 use crate::core::UndefinedStruct;
 use crate::{BoardTypeData, SMBiosStruct, SMBiosType};
 use serde::{ser::SerializeSeq, ser::SerializeStruct, Serialize, Serializer};
-use std::fmt;
-use std::ops::Deref;
+use core::{fmt, any};
+use core::ops::Deref;
+use alloc::{vec::Vec, string::String};
 
 /// # System Enclosure or Chassis (Type 3)
 ///
@@ -185,7 +186,7 @@ impl<'a> SMBiosSystemChassisInformation<'a> {
 
 impl fmt::Debug for SMBiosSystemChassisInformation<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SMBiosSystemChassisInformation<'_>>())
+        fmt.debug_struct(any::type_name::<SMBiosSystemChassisInformation<'_>>())
             .field("header", &self.parts.header)
             .field("manufacturer", &self.manufacturer())
             .field("chassis_type", &self.chassis_type())
@@ -306,7 +307,7 @@ pub struct ChassisTypeData {
 
 impl fmt::Debug for ChassisTypeData {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<ChassisTypeData>())
+        fmt.debug_struct(any::type_name::<ChassisTypeData>())
             .field("raw", &self.raw)
             .field("value", &self.value)
             .field("lock_presence", &self.lock_presence)
@@ -490,7 +491,7 @@ pub struct ChassisStateData {
 
 impl fmt::Debug for ChassisStateData {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<ChassisStateData>())
+        fmt.debug_struct(any::type_name::<ChassisStateData>())
             .field("raw", &self.raw)
             .field("value", &self.value)
             .finish()
@@ -568,7 +569,7 @@ pub struct ChassisSecurityStatusData {
 
 impl fmt::Debug for ChassisSecurityStatusData {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<ChassisSecurityStatusData>())
+        fmt.debug_struct(any::type_name::<ChassisSecurityStatusData>())
             .field("raw", &self.raw)
             .field("value", &self.value)
             .finish()
@@ -664,7 +665,7 @@ impl<'a> ContainedElements<'a> {
 
 impl<'a> fmt::Debug for ContainedElements<'a> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<ContainedElements<'_>>())
+        fmt.debug_struct(any::type_name::<ContainedElements<'_>>())
             .field("records", &self.into_iter())
             .finish()
     }
@@ -722,7 +723,7 @@ impl<'a> ChassisElement<'a> {
 
 impl fmt::Debug for ChassisElement<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<ChassisElement<'_>>())
+        fmt.debug_struct(any::type_name::<ChassisElement<'_>>())
             .field("raw", &self.raw)
             .field("element_type", &self.element_type())
             .field("element_minimum", &self.element_minimum())

--- a/src/structs/types/system_configuration_options.rs
+++ b/src/structs/types/system_configuration_options.rs
@@ -1,6 +1,6 @@
 use crate::{SMBiosStruct, Strings, UndefinedStruct};
 use serde::{ser::SerializeStruct, Serialize, Serializer};
-use std::fmt;
+use core::{fmt, any};
 
 /// # System Configuration Options (Type 12)
 ///
@@ -43,7 +43,7 @@ impl<'a> SMBiosSystemConfigurationOptions<'a> {
 
 impl fmt::Debug for SMBiosSystemConfigurationOptions<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SMBiosSystemConfigurationOptions<'_>>())
+        fmt.debug_struct(any::type_name::<SMBiosSystemConfigurationOptions<'_>>())
             .field("header", &self.parts.header)
             .field("count", &self.count())
             .field("configuration_strings", &self.configuration_strings())

--- a/src/structs/types/system_event_log.rs
+++ b/src/structs/types/system_event_log.rs
@@ -1,7 +1,8 @@
 use crate::{SMBiosStruct, UndefinedStruct};
 use serde::{ser::SerializeSeq, ser::SerializeStruct, Serialize, Serializer};
-use std::fmt;
-use std::ops::Deref;
+use core::{fmt, any};
+use core::ops::Deref;
+use alloc::vec::Vec;
 
 /// # System Event Log (Type 15)
 ///
@@ -132,7 +133,7 @@ impl<'a> SMBiosSystemEventLog<'a> {
 
 impl fmt::Debug for SMBiosSystemEventLog<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SMBiosSystemEventLog<'_>>())
+        fmt.debug_struct(any::type_name::<SMBiosSystemEventLog<'_>>())
             .field("header", &self.parts.header)
             .field("log_area_length", &self.log_area_length())
             .field("log_header_start_offset", &self.log_header_start_offset())
@@ -198,7 +199,7 @@ pub struct LogTypeData {
 
 impl fmt::Debug for LogTypeData {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<LogTypeData>())
+        fmt.debug_struct(any::type_name::<LogTypeData>())
             .field("raw", &self.raw)
             .field("value", &self.value)
             .finish()
@@ -336,7 +337,7 @@ pub struct VariableDataFormatTypeData {
 
 impl fmt::Debug for VariableDataFormatTypeData {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<VariableDataFormatTypeData>())
+        fmt.debug_struct(any::type_name::<VariableDataFormatTypeData>())
             .field("raw", &self.raw)
             .field("value", &self.value)
             .finish()
@@ -426,7 +427,7 @@ pub struct AccessMethodData {
 
 impl fmt::Debug for AccessMethodData {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<AccessMethodData>())
+        fmt.debug_struct(any::type_name::<AccessMethodData>())
             .field("raw", &self.raw)
             .field("value", &self.value)
             .finish()
@@ -547,7 +548,7 @@ impl<'a> EventLogTypeDescriptor<'a> {
 
 impl<'a> fmt::Debug for EventLogTypeDescriptor<'a> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<EventLogTypeDescriptor<'_>>())
+        fmt.debug_struct(any::type_name::<EventLogTypeDescriptor<'_>>())
             .field("raw", &self.raw)
             .field("log_type", &self.log_type())
             .field(
@@ -610,7 +611,7 @@ impl<'a> TypeDescriptors<'a> {
 
 impl<'a> fmt::Debug for TypeDescriptors<'a> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<TypeDescriptors<'_>>())
+        fmt.debug_struct(any::type_name::<TypeDescriptors<'_>>())
             .field("descriptors", &self.into_iter())
             .finish()
     }
@@ -737,7 +738,7 @@ impl LogStatus {
 
 impl fmt::Debug for LogStatus {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<LogStatus>())
+        fmt.debug_struct(any::type_name::<LogStatus>())
             .field("raw", &self.raw)
             .field("log_area_valid", &self.log_area_valid())
             .field("log_area_full", &self.log_area_full())
@@ -773,7 +774,7 @@ pub struct HeaderFormatData {
 
 impl fmt::Debug for HeaderFormatData {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<HeaderFormatData>())
+        fmt.debug_struct(any::type_name::<HeaderFormatData>())
             .field("raw", &self.raw)
             .field("value", &self.value)
             .finish()

--- a/src/structs/types/system_information.rs
+++ b/src/structs/types/system_information.rs
@@ -1,11 +1,13 @@
 use crate::{SMBiosStruct, UndefinedStruct};
 use serde::{ser::SerializeStruct, Serialize, Serializer};
-use std::{
+use core::{
     array::TryFromSliceError,
     convert::{TryFrom, TryInto},
     fmt,
     ops::Deref,
+    any
 };
+use alloc::{string::String, format};
 
 /// # System Information (Type 1)
 ///
@@ -102,7 +104,7 @@ impl<'a> SMBiosSystemInformation<'a> {
 
 impl fmt::Debug for SMBiosSystemInformation<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SMBiosSystemInformation<'_>>())
+        fmt.debug_struct(any::type_name::<SMBiosSystemInformation<'_>>())
             .field("header", &self.parts.header)
             .field("manufacturer", &self.manufacturer())
             .field("product_name", &self.product_name())
@@ -272,7 +274,7 @@ pub struct SystemWakeUpTypeData {
 
 impl fmt::Debug for SystemWakeUpTypeData {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SystemWakeUpTypeData>())
+        fmt.debug_struct(any::type_name::<SystemWakeUpTypeData>())
             .field("raw", &self.raw)
             .field("value", &self.value)
             .finish()

--- a/src/structs/types/system_power_controls.rs
+++ b/src/structs/types/system_power_controls.rs
@@ -1,6 +1,6 @@
 use crate::{SMBiosStruct, UndefinedStruct};
 use serde::{ser::SerializeStruct, Serialize, Serializer};
-use std::fmt;
+use core::{fmt, any};
 
 /// # System Power Controls (Type 25)
 ///
@@ -75,7 +75,7 @@ impl<'a> SMBiosSystemPowerControls<'a> {
 
 impl fmt::Debug for SMBiosSystemPowerControls<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SMBiosSystemPowerControls<'_>>())
+        fmt.debug_struct(any::type_name::<SMBiosSystemPowerControls<'_>>())
             .field("header", &self.parts.header)
             .field(
                 "next_scheduled_power_on_month",

--- a/src/structs/types/system_power_supply.rs
+++ b/src/structs/types/system_power_supply.rs
@@ -1,6 +1,7 @@
 use crate::{Handle, SMBiosStruct, UndefinedStruct};
 use serde::{ser::SerializeStruct, Serialize, Serializer};
-use std::fmt;
+use core::{fmt, any};
+use alloc::string::String;
 
 /// # System Power Supply (Type 39)
 ///
@@ -154,7 +155,7 @@ impl<'a> SMBiosSystemPowerSupply<'a> {
 
 impl fmt::Debug for SMBiosSystemPowerSupply<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SMBiosSystemPowerSupply<'_>>())
+        fmt.debug_struct(any::type_name::<SMBiosSystemPowerSupply<'_>>())
             .field("header", &self.parts.header)
             .field("power_unit_group", &self.power_unit_group())
             .field("location", &self.location())
@@ -267,7 +268,7 @@ impl PowerSupplyCharacteristics {
 
 impl fmt::Debug for PowerSupplyCharacteristics {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<PowerSupplyCharacteristics>())
+        fmt.debug_struct(any::type_name::<PowerSupplyCharacteristics>())
             .field("raw", &self.raw)
             .field("power_supply_type", &self.power_supply_type())
             .field("power_supply_status", &self.power_supply_status())

--- a/src/structs/types/system_reset.rs
+++ b/src/structs/types/system_reset.rs
@@ -1,6 +1,6 @@
 use crate::{SMBiosStruct, UndefinedStruct};
 use serde::{ser::SerializeStruct, Serialize, Serializer};
-use std::fmt;
+use core::{fmt, any};
 
 /// # System Reset (Type 23)
 ///
@@ -87,7 +87,7 @@ impl<'a> SMBiosSystemReset<'a> {
 
 impl fmt::Debug for SMBiosSystemReset<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SMBiosSystemReset<'_>>())
+        fmt.debug_struct(any::type_name::<SMBiosSystemReset<'_>>())
             .field("header", &self.parts.header)
             .field("capabilities", &self.capabilities())
             .field("reset_count", &self.reset_count())
@@ -161,7 +161,7 @@ impl SystemResetCapabilities {
 
 impl fmt::Debug for SystemResetCapabilities {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SystemResetCapabilities>())
+        fmt.debug_struct(any::type_name::<SystemResetCapabilities>())
             .field("raw", &self.raw)
             .field("has_watchdog_timer", &self.has_watchdog_timer())
             .field("boot_option_on_limit", &self.boot_option_on_limit())

--- a/src/structs/types/system_slot.rs
+++ b/src/structs/types/system_slot.rs
@@ -1,6 +1,7 @@
 use crate::{SMBiosStruct, UndefinedStruct};
 use serde::{ser::SerializeSeq, ser::SerializeStruct, Serialize, Serializer};
-use std::{convert::TryInto, fmt, ops::Deref};
+use core::{convert::TryInto, fmt, ops::Deref, any};
+use alloc::{vec::Vec, string::String};
 
 /// # System Slots (Type 9)
 ///
@@ -162,7 +163,7 @@ impl<'a> SMBiosSystemSlot<'a> {
 
 impl fmt::Debug for SMBiosSystemSlot<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SMBiosSystemSlot<'_>>())
+        fmt.debug_struct(any::type_name::<SMBiosSystemSlot<'_>>())
             .field("header", &self.parts.header)
             .field("slot_designation", &self.slot_designation())
             .field("system_slot_type", &self.system_slot_type())
@@ -366,7 +367,7 @@ impl From<u8> for SystemSlotTypeData {
 
 impl fmt::Debug for SystemSlotTypeData {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SystemSlotTypeData>())
+        fmt.debug_struct(any::type_name::<SystemSlotTypeData>())
             .field("raw", &self.raw)
             .field("value", &self.value)
             .finish()
@@ -598,7 +599,7 @@ impl From<u8> for SlotWidthData {
 
 impl fmt::Debug for SlotWidthData {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SlotWidthData>())
+        fmt.debug_struct(any::type_name::<SlotWidthData>())
             .field("raw", &self.raw)
             .field("value", &self.value)
             .finish()
@@ -691,7 +692,7 @@ impl From<u8> for SlotCurrentUsageData {
 
 impl fmt::Debug for SlotCurrentUsageData {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SlotCurrentUsageData>())
+        fmt.debug_struct(any::type_name::<SlotCurrentUsageData>())
             .field("raw", &self.raw)
             .field("value", &self.value)
             .finish()
@@ -768,7 +769,7 @@ impl From<u8> for SlotLengthData {
 
 impl fmt::Debug for SlotLengthData {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SlotLengthData>())
+        fmt.debug_struct(any::type_name::<SlotLengthData>())
             .field("raw", &self.raw)
             .field("value", &self.value)
             .finish()
@@ -873,7 +874,7 @@ impl SystemSlotCharacteristics1 {
 
 impl fmt::Debug for SystemSlotCharacteristics1 {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SystemSlotCharacteristics1>())
+        fmt.debug_struct(any::type_name::<SystemSlotCharacteristics1>())
             .field("raw", &self.raw)
             .field("unknown", &self.unknown())
             .field("provides5_volts", &self.provides5_volts())
@@ -983,7 +984,7 @@ impl SystemSlotCharacteristics2 {
 
 impl fmt::Debug for SystemSlotCharacteristics2 {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SystemSlotCharacteristics2>())
+        fmt.debug_struct(any::type_name::<SystemSlotCharacteristics2>())
             .field("raw", &self.raw)
             .field(
                 "supports_power_management_event",
@@ -1160,7 +1161,7 @@ impl<'a> SlotPeerGroup<'a> {
 
 impl fmt::Debug for SlotPeerGroup<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SlotPeerGroup<'_>>())
+        fmt.debug_struct(any::type_name::<SlotPeerGroup<'_>>())
             .field("segment_group_number", &self.segment_group_number())
             .field("bus_number", &self.bus_number())
             .field("device_function_number", &self.device_function_number())

--- a/src/structs/types/temperature_probe.rs
+++ b/src/structs/types/temperature_probe.rs
@@ -1,6 +1,7 @@
 use crate::{SMBiosStruct, UndefinedStruct};
 use serde::{ser::SerializeStruct, Serialize, Serializer};
-use std::fmt;
+use core::{fmt, any};
+use alloc::string::String;
 
 /// # Temperature Probe (Type 28)
 ///
@@ -118,7 +119,7 @@ impl<'a> SMBiosTemperatureProbe<'a> {
 
 impl fmt::Debug for SMBiosTemperatureProbe<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SMBiosTemperatureProbe<'_>>())
+        fmt.debug_struct(any::type_name::<SMBiosTemperatureProbe<'_>>())
             .field("header", &self.parts.header)
             .field("description", &self.description())
             .field("location_and_status", &self.location_and_status())
@@ -180,7 +181,7 @@ impl TemperatureProbeLocationAndStatus {
 
 impl fmt::Debug for TemperatureProbeLocationAndStatus {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<TemperatureProbeLocationAndStatus>())
+        fmt.debug_struct(any::type_name::<TemperatureProbeLocationAndStatus>())
             .field("raw", &self.raw)
             .field("location", &self.location())
             .field("status", &self.status())

--- a/src/structs/types/tpm_device.rs
+++ b/src/structs/types/tpm_device.rs
@@ -1,6 +1,7 @@
 use crate::{SMBiosStruct, UndefinedStruct};
 use serde::{ser::SerializeStruct, Serialize, Serializer};
-use std::{array::TryFromSliceError, convert::TryFrom, fmt, ops::Deref};
+use core::{array::TryFromSliceError, convert::TryFrom, fmt, ops::Deref, any};
+use alloc::string::String;
 
 /// # TPM Device (Type 43)
 pub struct SMBiosTpmDevice<'a> {
@@ -106,7 +107,7 @@ impl<'a> SMBiosTpmDevice<'a> {
 
 impl fmt::Debug for SMBiosTpmDevice<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SMBiosTpmDevice<'_>>())
+        fmt.debug_struct(any::type_name::<SMBiosTpmDevice<'_>>())
             .field("header", &self.parts.header)
             .field("vendor_id", &self.vendor_id())
             .field("major_spec_version", &self.major_spec_version())
@@ -162,7 +163,7 @@ impl<'a> TryFrom<&'a [u8]> for VendorId<'a> {
 
 impl<'a> fmt::Debug for VendorId<'a> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<VendorId<'_>>())
+        fmt.debug_struct(any::type_name::<VendorId<'_>>())
             .field("array", &self.array)
             .field("string", &String::from_utf8_lossy(self.array))
             .finish()
@@ -241,7 +242,7 @@ impl TpmDeviceCharacteristics {
 
 impl fmt::Debug for TpmDeviceCharacteristics {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<TpmDeviceCharacteristics>())
+        fmt.debug_struct(any::type_name::<TpmDeviceCharacteristics>())
             .field("raw", &self.raw)
             .field("reserved_0", &self.reserved_0())
             .field("reserved_1", &self.reserved_1())

--- a/src/structs/types/unknown.rs
+++ b/src/structs/types/unknown.rs
@@ -1,6 +1,6 @@
 use crate::{Header, UndefinedStruct};
 use serde::{ser::SerializeStruct, Serialize, Serializer};
-use std::fmt;
+use core::{fmt, any};
 
 /// # OEM or Unknown Structure
 ///
@@ -33,7 +33,7 @@ impl<'a> SMBiosUnknown<'a> {
 impl fmt::Debug for SMBiosUnknown<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         let fields = &self.parts.fields[Header::SIZE..];
-        fmt.debug_struct(std::any::type_name::<SMBiosUnknown<'_>>())
+        fmt.debug_struct(any::type_name::<SMBiosUnknown<'_>>())
             .field("header", &self.parts.header)
             .field("fields", &fields)
             .field("strings", &self.parts.strings)

--- a/src/structs/types/voltage_probe.rs
+++ b/src/structs/types/voltage_probe.rs
@@ -1,6 +1,7 @@
 use crate::{SMBiosStruct, UndefinedStruct};
 use serde::{ser::SerializeStruct, Serialize, Serializer};
-use std::fmt;
+use core::{fmt, any};
+use alloc::string::String;
 
 /// #  Voltage Probe (Type 26)
 ///
@@ -111,7 +112,7 @@ impl<'a> SMBiosVoltageProbe<'a> {
 
 impl fmt::Debug for SMBiosVoltageProbe<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<SMBiosVoltageProbe<'_>>())
+        fmt.debug_struct(any::type_name::<SMBiosVoltageProbe<'_>>())
             .field("header", &self.parts.header)
             .field("description", &self.description())
             .field("location_and_status", &self.location_and_status())
@@ -173,7 +174,7 @@ impl VoltageProbeLocationAndStatus {
 
 impl fmt::Debug for VoltageProbeLocationAndStatus {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct(std::any::type_name::<VoltageProbeLocationAndStatus>())
+        fmt.debug_struct(any::type_name::<VoltageProbeLocationAndStatus>())
             .field("raw", &self.raw)
             .field("location", &self.location())
             .field("status", &self.status())

--- a/src/x86_64/mod.rs
+++ b/src/x86_64/mod.rs
@@ -1,0 +1,30 @@
+//! X86_64 no-std SMBIOS.
+//!
+//! Functions and structures for working with SMBIOS on no-std x86_64 environments.
+//!
+//! # Example
+//! ```rust
+//! use x86_64::{PhysAddr, VirtAddr};
+//! use smbioslib::{MemoryMapper, table_load_from_device};
+//! struct MemoryMapperImpl {}
+//!
+//! impl MemoryMapper for MemoryMapperImpl {
+//!     fn map_block(&mut self, addr: PhysAddr, size: usize) -> VirtAddr {
+//!         // map physical block to virtual space
+//!         VirtAddr::new(addr.as_u64())
+//!     }
+//! }
+//!
+//! fn smbios_dump() {
+//!     let mut mapper = MemoryMapperImpl {};
+//!     match table_load_from_device(&mut mapper) {
+//!         Ok(data) => {
+//!             println!("smbios_data: {:#?}", data);
+//!         }
+//!         Err(err) => panic!("failure: {:?}", err),
+//!     }
+//! }
+//! ```
+mod platform;
+
+pub use platform::*;

--- a/src/x86_64/platform.rs
+++ b/src/x86_64/platform.rs
@@ -1,0 +1,100 @@
+use crate::{SMBiosVersion, SMBiosData, SMBiosEntryPoint64, SMBiosEntryPoint32, SMBiosEntryPoint64Error, SMBiosEntryPoint32Error};
+use x86_64::{VirtAddr, PhysAddr};
+use core::{slice, fmt};
+use alloc::format;
+
+const BLOCK_START: PhysAddr = PhysAddr::new_truncate(0xF0000);
+const BLOCK_SIZE: usize = 0xFFFFF - 0xF0000;
+
+/// A trait for mapping/unmapping physical memory blocks
+pub trait MemoryMapper {
+    /// Map physical memory block to virtual memory space
+    fn map_block(&mut self, addr: PhysAddr, size: usize) -> VirtAddr;
+
+    /// Unmap physical memory block from virtual memory space
+    #[allow(unused_variables)]
+    fn unmap_block(&mut self, addr: PhysAddr, virt_addr: VirtAddr, size: usize) {}
+}
+
+/// SMBios table load errors
+pub enum SMBiosLoadError {
+    /// Entry Point Structure checksum verification failed
+    EntryChecksumVerificationFailed,
+    /// The Entry Point Length field specified a value which exceeded the bounds of the Entry Point Structure
+    EntryPointLengthTooBig,
+    /// Intermediate entry point structure checksum verification failed
+    IntermediateChecksumVerificationFailed,
+    /// Entry Point not found
+    EntryPointNotFound,
+}
+
+impl fmt::Debug for SMBiosLoadError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("SMBiosLoadError")
+            .field(&format!("{}", &self))
+            .finish()
+    }
+}
+
+impl fmt::Display for SMBiosLoadError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let message = match self {
+            SMBiosLoadError::EntryChecksumVerificationFailed => "Entry Point Structure checksum verification failed",
+            SMBiosLoadError::EntryPointLengthTooBig => "The Entry Point Length field specified a value which exceeded the bounds of the Entry Point Structure",
+            SMBiosLoadError::IntermediateChecksumVerificationFailed => "Intermediate entry point structure checksum verification failed",
+            SMBiosLoadError::EntryPointNotFound => "Entry Point not found"
+        };
+        f.write_str(message)
+    }
+}
+
+
+/// Loads [SMBiosData] by scanning memory from 0xF0000 to 0xFFFFF
+pub fn table_load_from_device<T: MemoryMapper>(mapper: &mut T) -> Result<SMBiosData, SMBiosLoadError> {
+    let start = mapper.map_block(BLOCK_START, BLOCK_SIZE);
+
+    let slice: &[u8] = unsafe { slice::from_raw_parts(start.as_ptr(), BLOCK_SIZE) };
+    let version: SMBiosVersion;
+    let data_start: PhysAddr;
+    let data_length: usize;
+
+    match SMBiosEntryPoint64::try_scan_from_raw(slice) {
+        Ok(entry_point) => {
+            version = SMBiosVersion {
+                major: entry_point.major_version(),
+                minor: entry_point.minor_version(),
+                revision: entry_point.docrev(),
+            };
+            data_start = PhysAddr::new(entry_point.structure_table_address());
+            data_length = entry_point.structure_table_maximum_size() as usize;
+        }
+        Err(e) => match e {
+            SMBiosEntryPoint64Error::EntryPointLengthTooBig => return Err(SMBiosLoadError::EntryPointLengthTooBig),
+            SMBiosEntryPoint64Error::ChecksumVerificationFailed => return Err(SMBiosLoadError::EntryChecksumVerificationFailed),
+            _ => match SMBiosEntryPoint32::try_scan_from_raw(slice) {
+                Ok(entry_point) => {
+                    version = SMBiosVersion {
+                        major: entry_point.major_version(),
+                        minor: entry_point.minor_version(),
+                        revision: 0,
+                    };
+                    data_start = PhysAddr::new(entry_point.structure_table_address() as u64);
+                    data_length = entry_point.structure_table_length() as usize;
+                },
+                Err(e) => return Err(match e {
+                    SMBiosEntryPoint32Error::EntryChecksumVerificationFailed => SMBiosLoadError::EntryChecksumVerificationFailed,
+                    SMBiosEntryPoint32Error::IntermediateChecksumVerificationFailed => SMBiosLoadError::IntermediateChecksumVerificationFailed,
+                    SMBiosEntryPoint32Error::EntryPointLengthTooBig => SMBiosLoadError::EntryPointLengthTooBig,
+                    _ => SMBiosLoadError::EntryPointNotFound
+                })
+            }
+        },
+    }
+    mapper.unmap_block(BLOCK_START, start, BLOCK_SIZE);
+
+    let data_start_virt = mapper.map_block(data_start, data_length);
+    let data_slice: &[u8] = unsafe { slice::from_raw_parts(data_start_virt.as_ptr(), data_length) };
+    let data = SMBiosData::from_vec_and_version(data_slice.to_vec(), Some(version));
+    mapper.unmap_block(data_start, data_start_virt, data_length);
+    Ok(data)
+}


### PR DESCRIPTION
This PR:
- Adds `no_std` compatibility to this library
- Adds method to find smbios entry in raw memory using `x86_64` crate