### PR TITLE
Remove range check for FreeBSD

### DIFF
--- a/src/unix/platform.rs
+++ b/src/unix/platform.rs
@@ -119,16 +119,6 @@ pub fn table_load_from_device() -> Result<SMBiosData, Error> {
         }
     }
 
-    if structure_table_address < RANGE_START || structure_table_address > RANGE_END {
-        return Err(Error::new(
-            ErrorKind::InvalidData,
-            format!(
-                "The entry point has given an out of range start address for the table: {}",
-                structure_table_address
-            ),
-        ));
-    }
-
     if structure_table_address + structure_table_length as u64 > RANGE_END {
         return Err(Error::new(
             ErrorKind::InvalidData,
@@ -271,16 +261,6 @@ mod tests {
                 );
                 println!("Table at: {:#010X}.", entry_point.structure_table_address());
             }
-        }
-
-        if structure_table_address < RANGE_START || structure_table_address > RANGE_END {
-            return Err(Error::new(
-                ErrorKind::InvalidData,
-                format!(
-                    "The entry point has given an out of range start address for the table: {}",
-                    structure_table_address
-                ),
-            ));
         }
 
         if structure_table_address + structure_table_length as u64 > RANGE_END {


### PR DESCRIPTION
It appears that on FreeBSD it is possible for the SMBios table can be mapped below the 0xf0000 address range. Below is section of truss output from dmidecode loading the smbios table on my FreeBSD 13.0 system. It starts looking for the entry point at 0xF0000, but the table actually starts at 0xE80000.

    mmap(0x0,65536,PROT_READ,MAP_SHARED,3,0xf0000)   = 34366488576 (0x800670000)
    munmap(0x800670000,65536)                        = 0 (0x0)
    close(3)                                         = 0 (0x0)
    SMBIOS 3.3.0 present.
    write(1,"SMBIOS 3.3.0 present.\n",22)            = 22 (0x16)
    Table at 0x000E8D60.
    write(1,"Table at 0x000E8D60.\n",21)             = 21 (0x15)
    
    write(1,"\n",1)                                  = 1 (0x1)
    openat(AT_FDCWD,"/dev/mem",O_RDONLY,00)          = 3 (0x3)
    fstat(3,{ mode=crw-r----- ,inode=39,size=0,blksize=4096 }) = 0 (0x0)
    mmap(0x0,5783,PROT_READ,MAP_SHARED,3,0xe8000)    = 34366488576 (0x800670000)

This pull request removes the bounds check for where the table resides in the /dev/mem file. I am not sure that the check for the address being too high is wrong or not, but I think it should be caught by the next test anyway.

```rust
        if structure_table_address + structure_table_length as u64 > RANGE_END {
            return Err(Error::new(
                ErrorKind::InvalidData,
                format!(
                    "The entry point has given a length which exceeds the range: {}",
                    structure_table_length
                ),
            ));
        }
```
