### PR TITLE
Spec 3.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smbios-lib"
-version = "0.8.1"
+version = "0.8.2"
 authors = ["Jeffrey R. Gerber <jeffreygerber@gmail.com>", "Ante Čulo <dante2711@gmail.com>", "Juan Zuluaga <juzuluag@hotmail.com>"]
 license-file = "LICENSE"
 edition = "2018"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smbios-lib"
-version = "0.8.2"
+version = "0.9.0"
 authors = ["Jeffrey R. Gerber <jeffreygerber@gmail.com>", "Ante Čulo <dante2711@gmail.com>", "Juan Zuluaga <juzuluag@hotmail.com>"]
 license-file = "LICENSE"
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ For an example project using this library take a look at [dmidecode-rs](https://
 
 ### Supports
 * [DMTF System Management BIOS (SMBIOS) Reference
-Specification 3.4.0](https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.4.0.pdf)
+Specification 3.5.0](https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.5.0.pdf)
 * Linux
 * MacOS
 * Windows family
 
-> SMBIOS 3.4.0 contains 47 defined structure types, all of which are covered by this library (types 0-44, 126, and 127).  Support via extensibility exists for types 128-255 (reserved for OEMs).  Extensibility also applies in the case when this library has not been updated for the latest specification version or a pre-released specification and a new type is introduced.
+> SMBIOS 3.5.0 contains 49 defined structure types, all of which are covered by this library (types 0-46, 126, and 127).  Support via extensibility exists for types 128-255 (reserved for OEMs).  Extensibility also applies in the case when this library has not been updated for the latest specification version or a pre-released specification and a new type is introduced.
 
 ### Project Status
 In early development.

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,7 +1,8 @@
 mod entry_point;
 mod header;
 mod smbios_data;
-mod strings;
+/// SMBIOS String module
+pub mod strings;
 mod undefined_struct;
 
 pub use entry_point::*;

--- a/src/core/strings.rs
+++ b/src/core/strings.rs
@@ -43,6 +43,16 @@ impl Strings {
             return None;
         }
 
+        // TODO: Temporary comments for this Pull Request to draw attention to this and make a decision how to proceed.
+        //
+        // As of 3.5.0 DMTF has decided to make UTF-8 the standard for how to interpret strings.
+        // The below needs to change to interpret the byte array as UTF-8.
+        //
+        // 6.1.3 "Strings must be encoded as UTF-8 with no byte order mark (BOM). For compatibility with older SMBIOS
+        // parsers, US-ASCII characters should be used."
+        //
+        // What is confusing about the statement is that in UTF-8 the first 128 characters *are* US-ASCII.
+
         // Create an ISO-8859-1 String.  Each `u8 as char` operation maps a u8
         // value (0xNN) to a Unicode code point (0x00NN).
         //

--- a/src/core/strings.rs
+++ b/src/core/strings.rs
@@ -72,7 +72,7 @@ impl Strings {
 }
 
 impl Iterator for Strings {
-    type Item = String;
+    type Item = Result<String, FromUtf8Error>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.current_string_index == self.strings.len() {
@@ -80,11 +80,8 @@ impl Iterator for Strings {
             return None;
         }
 
-        // "*x as char" is ISO-8859-1.
-        let result: String = self.strings[self.current_string_index]
-            .iter()
-            .map(|x| *x as char)
-            .collect();
+        let result = String::from_utf8(self.strings[self.current_string_index].clone());
+
         self.current_string_index = self.current_string_index + 1;
 
         Some(result)
@@ -92,7 +89,7 @@ impl Iterator for Strings {
 }
 
 impl IntoIterator for &Strings {
-    type Item = String;
+    type Item = Result<String, FromUtf8Error>;
     type IntoIter = Strings;
 
     fn into_iter(self) -> Self::IntoIter {
@@ -114,10 +111,13 @@ impl Serialize for Strings {
     where
         S: Serializer,
     {
-        let strings: Vec<String> = self.into_iter().collect();
+        let strings: Vec<Result<String, FromUtf8Error>> = self.into_iter().collect();
         let mut seq = serializer.serialize_seq(Some(strings.len()))?;
         for e in strings {
-            seq.serialize_element(&e)?;
+            match e {
+                Ok(val) => seq.serialize_element(&val)?,
+                Err(err) => seq.serialize_element(format!("{}", err).as_str())?,
+            }
         }
         seq.end()
     }
@@ -186,5 +186,48 @@ impl error::Error for SMBiosStringError {
 impl From<FromUtf8Error> for SMBiosStringError {
     fn from(err: FromUtf8Error) -> SMBiosStringError {
         SMBiosStringError::Utf8(err)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_string_parsing() {
+        let string_set_bytes = vec![
+            // "en|US|iso8859-1"
+            0x65, 0x6E, 0x7C, 0x55, 0x53, 0x7C, 0x69, 0x73, 0x6F, 0x38, 0x38, 0x35, 0x39, 0x2D,
+            0x31, 0x00, // "Heart=💖"
+            b'H', b'e', b'a', b'r', b't', b'=', 240, 159, 146, 150, 0x00, // "Error="
+            b'E', b'r', b'r', b'o', b'r', b'=', 1, 159, 146, 150, 0x00,
+            // "ja|JP|unicode"
+            0x6A, 0x61, 0x7C, 0x4A, 0x50, 0x7C, 0x75, 0x6E, 0x69, 0x63, 0x6F, 0x64, 0x65,
+        ];
+
+        let string_set = Strings::new(string_set_bytes);
+
+        let mut string_iterator = string_set.into_iter();
+
+        let first_string = string_iterator.next().unwrap().unwrap();
+        assert_eq!(first_string, "en|US|iso8859-1".to_string());
+
+        let second_string = string_iterator.next().unwrap().unwrap();
+        assert_eq!(second_string, "Heart=💖".to_string());
+
+        // Err(FromUtf8Error { bytes: [69, 114, 114, 111, 114, 61, 1, 159, 146, 150], error: Utf8Error { valid_up_to: 7, error_len: Some(1) } })
+        match string_iterator.next().unwrap() {
+            Ok(_) => panic!("This should have been a UTF8 error"),
+            Err(err) => {
+                assert_eq!(7, err.utf8_error().valid_up_to());
+                assert_eq!(
+                    "Error=\u{1}���",
+                    String::from_utf8_lossy(err.as_bytes()).to_string()
+                );
+            }
+        }
+
+        let fourth_string = string_iterator.next().unwrap().unwrap();
+        assert_eq!(fourth_string, "ja|JP|unicode".to_string());
     }
 }

--- a/src/core/undefined_struct.rs
+++ b/src/core/undefined_struct.rs
@@ -129,11 +129,10 @@ impl<'a> UndefinedStruct {
     /// The string is thus retrieved from the strings section based on the
     /// byte value at the given offset.
     pub fn get_field_string(&self, offset: usize) -> SMBiosString {
-        let result = match self.get_field_byte(offset) {
+        match self.get_field_byte(offset) {
             Some(val) => self.strings.get_string(val),
-            None => Err(SMBiosStringError::FieldOutOfBounds),
-        };
-        result.into()
+            None => Err(SMBiosStringError::FieldOutOfBounds).into(),
+        }
     }
 
     // todo: learn how to pass an index range (SliceIndex?) rather than start/end indices.

--- a/src/core/undefined_struct.rs
+++ b/src/core/undefined_struct.rs
@@ -1,5 +1,5 @@
 use super::header::{Handle, Header};
-use super::strings::Strings;
+use super::strings::{SMBiosStringError, Strings};
 use crate::structs::{DefinedStruct, SMBiosEndOfTable, SMBiosStruct};
 use serde::{Serialize, Serializer};
 use std::fmt;
@@ -128,10 +128,10 @@ impl<'a> UndefinedStruct {
     /// contains a byte whose value is a 1 based index into the strings section.
     /// The string is thus retrieved from the strings section based on the
     /// byte value at the given offset.
-    pub fn get_field_string(&self, offset: usize) -> Option<String> {
+    pub fn get_field_string(&self, offset: usize) -> Result<String, SMBiosStringError> {
         match self.get_field_byte(offset) {
             Some(val) => self.strings.get_string(val),
-            None => None,
+            None => Err(SMBiosStringError::FieldOutOfBounds),
         }
     }
 

--- a/src/core/undefined_struct.rs
+++ b/src/core/undefined_struct.rs
@@ -1,5 +1,5 @@
 use super::header::{Handle, Header};
-use super::strings::{SMBiosStringError, Strings};
+use super::strings::*;
 use crate::structs::{DefinedStruct, SMBiosEndOfTable, SMBiosStruct};
 use serde::{Serialize, Serializer};
 use std::fmt;
@@ -49,10 +49,10 @@ pub struct UndefinedStruct {
 
     /// The strings of the structure
     #[serde(serialize_with = "ser_strings")]
-    pub strings: Strings,
+    pub strings: SMBiosStringSet,
 }
 
-fn ser_strings<S>(data: &Strings, serializer: S) -> Result<S::Ok, S::Error>
+fn ser_strings<S>(data: &SMBiosStringSet, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {
@@ -67,7 +67,7 @@ impl<'a> UndefinedStruct {
                 header: Header::new(raw[..Header::SIZE].try_into().expect("4 bytes")),
                 fields: raw.get(..(header_length as usize)).unwrap_or(&[]).to_vec(),
                 strings: {
-                    Strings::new(
+                    SMBiosStringSet::new(
                         raw.get((header_length as usize)..raw.len() - 2)
                             .unwrap_or(&[])
                             .to_vec(),
@@ -128,11 +128,12 @@ impl<'a> UndefinedStruct {
     /// contains a byte whose value is a 1 based index into the strings section.
     /// The string is thus retrieved from the strings section based on the
     /// byte value at the given offset.
-    pub fn get_field_string(&self, offset: usize) -> Result<String, SMBiosStringError> {
-        match self.get_field_byte(offset) {
+    pub fn get_field_string(&self, offset: usize) -> SMBiosString {
+        let result = match self.get_field_byte(offset) {
             Some(val) => self.strings.get_string(val),
             None => Err(SMBiosStringError::FieldOutOfBounds),
-        }
+        };
+        result.into()
     }
 
     // todo: learn how to pass an index range (SliceIndex?) rather than start/end indices.
@@ -185,7 +186,7 @@ impl Default for UndefinedStruct {
         UndefinedStruct {
             header: Header::new(v),
             fields: (&[]).to_vec(),
-            strings: { Strings::new((&[]).to_vec()) },
+            strings: { SMBiosStringSet::new((&[]).to_vec()) },
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! SMBIOS Library
 //!
-//! Implements the DMTF [System Management BIOS (SMBIOS) Reference Specification 3.4.0](https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.4.0.pdf).
+//! Implements the DMTF [System Management BIOS (SMBIOS) Reference Specification 3.5.0](https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.5.0.pdf).
 //!
 //! This library focuses on the tasks involved with reading and interpreting
 //! BIOS data.

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,42 +49,15 @@ impl Display for BiosParseError {
 
 fn string_keyword(keyword: String, data: &SMBiosData) -> Result<String, BiosParseError> {
     match keyword.to_lowercase().as_str() {
-        "bios-vendor" => match data.first::<SMBiosInformation>() {
-            Some(bios_info) => match bios_info.vendor() {
-                Ok(vendor) => Ok(vendor),
-                Err(err) => match err {
-                    SMBiosStringError::Utf8(utf8) => {
-                        Ok(String::from_utf8_lossy(utf8.as_bytes()).to_string())
-                    }
-                    _ => Err(BiosParseError::BiosVendorNotFound),
-                },
-            },
-            None => Err(BiosParseError::BiosVendorNotFound),
-        },
-        "bios-version" => match data.first::<SMBiosInformation>() {
-            Some(bios_info) => match bios_info.version() {
-                Ok(version) => Ok(version),
-                Err(err) => match err {
-                    SMBiosStringError::Utf8(utf8) => {
-                        Ok(String::from_utf8_lossy(utf8.as_bytes()).to_string())
-                    }
-                    _ => Err(BiosParseError::BiosVersionNotFound),
-                },
-            },
-            None => Err(BiosParseError::BiosVersionNotFound),
-        },
-        "bios-release-date" => match data.first::<SMBiosInformation>() {
-            Some(bios_info) => match bios_info.release_date() {
-                Ok(release_date) => Ok(release_date),
-                Err(err) => match err {
-                    SMBiosStringError::Utf8(utf8) => {
-                        Ok(String::from_utf8_lossy(utf8.as_bytes()).to_string())
-                    }
-                    _ => Err(BiosParseError::BiosReleaseDateNotFound),
-                },
-            },
-            None => Err(BiosParseError::BiosReleaseDateNotFound),
-        },
+        "bios-vendor" => data
+            .find_map(|bios_info: SMBiosInformation| bios_info.vendor().to_utf8_lossy())
+            .ok_or(BiosParseError::BiosVendorNotFound),
+        "bios-version" => data
+            .find_map(|bios_info: SMBiosInformation| bios_info.version().to_utf8_lossy())
+            .ok_or(BiosParseError::BiosVersionNotFound),
+        "bios-release-date" => data
+            .find_map(|bios_info: SMBiosInformation| bios_info.release_date().to_utf8_lossy())
+            .ok_or(BiosParseError::BiosReleaseDateNotFound),
         "bios-revision" => data
             .find_map(|bios_info: SMBiosInformation| {
                 match (
@@ -107,54 +80,24 @@ fn string_keyword(keyword: String, data: &SMBiosData) -> Result<String, BiosPars
                 }
             })
             .ok_or(BiosParseError::FirmewareRevisionNotFound),
-        "system-manufacturer" => match data.first::<SMBiosSystemInformation>() {
-            Some(system_info) => match system_info.manufacturer() {
-                Ok(manufacturer) => Ok(manufacturer),
-                Err(err) => match err {
-                    SMBiosStringError::Utf8(utf8) => {
-                        Ok(String::from_utf8_lossy(utf8.as_bytes()).to_string())
-                    }
-                    _ => Err(BiosParseError::SystemManufacturerNotFound),
-                },
-            },
-            None => Err(BiosParseError::SystemManufacturerNotFound),
-        },
-        "system-product-name" => match data.first::<SMBiosSystemInformation>() {
-            Some(system_info) => match system_info.product_name() {
-                Ok(system_product_name) => Ok(system_product_name),
-                Err(err) => match err {
-                    SMBiosStringError::Utf8(utf8) => {
-                        Ok(String::from_utf8_lossy(utf8.as_bytes()).to_string())
-                    }
-                    _ => Err(BiosParseError::SystemProductNameNotFound),
-                },
-            },
-            None => Err(BiosParseError::SystemProductNameNotFound),
-        },
-        "system-version" => match data.first::<SMBiosSystemInformation>() {
-            Some(system_info) => match system_info.version() {
-                Ok(version) => Ok(version),
-                Err(err) => match err {
-                    SMBiosStringError::Utf8(utf8) => {
-                        Ok(String::from_utf8_lossy(utf8.as_bytes()).to_string())
-                    }
-                    _ => Err(BiosParseError::SystemVersionNotFound),
-                },
-            },
-            None => Err(BiosParseError::SystemVersionNotFound),
-        },
-        "system-serial-number" => match data.first::<SMBiosSystemInformation>() {
-            Some(system_info) => match system_info.serial_number() {
-                Ok(serial_number) => Ok(serial_number),
-                Err(err) => match err {
-                    SMBiosStringError::Utf8(utf8) => {
-                        Ok(String::from_utf8_lossy(utf8.as_bytes()).to_string())
-                    }
-                    _ => Err(BiosParseError::SystemSerialNumberNotFound),
-                },
-            },
-            None => Err(BiosParseError::SystemSerialNumberNotFound),
-        },
+        "system-manufacturer" => data
+            .find_map(|system_info: SMBiosSystemInformation| {
+                system_info.manufacturer().to_utf8_lossy()
+            })
+            .ok_or(BiosParseError::SystemManufacturerNotFound),
+        "system-product-name" => data
+            .find_map(|system_info: SMBiosSystemInformation| {
+                system_info.product_name().to_utf8_lossy()
+            })
+            .ok_or(BiosParseError::SystemProductNameNotFound),
+        "system-version" => data
+            .find_map(|system_info: SMBiosSystemInformation| system_info.version().to_utf8_lossy())
+            .ok_or(BiosParseError::SystemVersionNotFound),
+        "system-serial-number" => data
+            .find_map(|system_info: SMBiosSystemInformation| {
+                system_info.serial_number().to_utf8_lossy()
+            })
+            .ok_or(BiosParseError::SystemSerialNumberNotFound),
         "system-uuid" => {
             match data.find_map(|system_info: SMBiosSystemInformation| system_info.uuid()) {
                 // SystemUuidData is an enum that can be broken down further if desired
@@ -162,144 +105,65 @@ fn string_keyword(keyword: String, data: &SMBiosData) -> Result<String, BiosPars
                 None => Err(BiosParseError::SystemUuidNotFound),
             }
         }
-        "system-sku-number" => match data.first::<SMBiosSystemInformation>() {
-            Some(system_info) => match system_info.sku_number() {
-                Ok(sku_number) => Ok(sku_number),
-                Err(err) => match err {
-                    SMBiosStringError::Utf8(utf8) => {
-                        Ok(String::from_utf8_lossy(utf8.as_bytes()).to_string())
-                    }
-                    _ => Err(BiosParseError::SystemSkuNumberNotFound),
-                },
-            },
-            None => Err(BiosParseError::SystemSkuNumberNotFound),
-        },
-        "system-family" => match data.first::<SMBiosSystemInformation>() {
-            Some(system_info) => match system_info.family() {
-                Ok(family) => Ok(family),
-                Err(err) => match err {
-                    SMBiosStringError::Utf8(utf8) => {
-                        Ok(String::from_utf8_lossy(utf8.as_bytes()).to_string())
-                    }
-                    _ => Err(BiosParseError::SystemFamilyNotFound),
-                },
-            },
-            None => Err(BiosParseError::SystemFamilyNotFound),
-        },
-        "baseboard-manufacturer" => match data.first::<SMBiosBaseboardInformation>() {
-            Some(baseboard_info) => match baseboard_info.manufacturer() {
-                Ok(manufacturer) => Ok(manufacturer),
-                Err(err) => match err {
-                    SMBiosStringError::Utf8(utf8) => {
-                        Ok(String::from_utf8_lossy(utf8.as_bytes()).to_string())
-                    }
-                    _ => Err(BiosParseError::BaseboardManufacturerNotFound),
-                },
-            },
-            None => Err(BiosParseError::BaseboardManufacturerNotFound),
-        },
-        "baseboard-product-name" => match data.first::<SMBiosBaseboardInformation>() {
-            Some(baseboard_info) => match baseboard_info.product() {
-                Ok(product) => Ok(product),
-                Err(err) => match err {
-                    SMBiosStringError::Utf8(utf8) => {
-                        Ok(String::from_utf8_lossy(utf8.as_bytes()).to_string())
-                    }
-                    _ => Err(BiosParseError::BaseboardProductNameNotFound),
-                },
-            },
-            None => Err(BiosParseError::BaseboardProductNameNotFound),
-        },
-        "baseboard-version" => match data.first::<SMBiosBaseboardInformation>() {
-            Some(baseboard_info) => match baseboard_info.version() {
-                Ok(version) => Ok(version),
-                Err(err) => match err {
-                    SMBiosStringError::Utf8(utf8) => {
-                        Ok(String::from_utf8_lossy(utf8.as_bytes()).to_string())
-                    }
-                    _ => Err(BiosParseError::BaseboardVersionNotFound),
-                },
-            },
-            None => Err(BiosParseError::BaseboardVersionNotFound),
-        },
-        "baseboard-serial-number" => match data.first::<SMBiosBaseboardInformation>() {
-            Some(baseboard_info) => match baseboard_info.serial_number() {
-                Ok(serial_number) => Ok(serial_number),
-                Err(err) => match err {
-                    SMBiosStringError::Utf8(utf8) => {
-                        Ok(String::from_utf8_lossy(utf8.as_bytes()).to_string())
-                    }
-                    _ => Err(BiosParseError::BaseboardSerialNumberNotFound),
-                },
-            },
-            None => Err(BiosParseError::BaseboardSerialNumberNotFound),
-        },
-        "baseboard-asset-tag" => match data.first::<SMBiosBaseboardInformation>() {
-            Some(baseboard_info) => match baseboard_info.asset_tag() {
-                Ok(asset_tag) => Ok(asset_tag),
-                Err(err) => match err {
-                    SMBiosStringError::Utf8(utf8) => {
-                        Ok(String::from_utf8_lossy(utf8.as_bytes()).to_string())
-                    }
-                    _ => Err(BiosParseError::BaseboardAssetTagNotFound),
-                },
-            },
-            None => Err(BiosParseError::BaseboardAssetTagNotFound),
-        },
-        "chassis-manufacturer" => match data.first::<SMBiosSystemChassisInformation>() {
-            Some(chassis_info) => match chassis_info.manufacturer() {
-                Ok(manufacturer) => Ok(manufacturer),
-                Err(err) => match err {
-                    SMBiosStringError::Utf8(utf8) => {
-                        Ok(String::from_utf8_lossy(utf8.as_bytes()).to_string())
-                    }
-                    _ => Err(BiosParseError::ChassisManufacturerNotFound),
-                },
-            },
-            None => Err(BiosParseError::ChassisManufacturerNotFound),
-        },
+        "system-sku-number" => data
+            .find_map(|system_info: SMBiosSystemInformation| {
+                system_info.sku_number().to_utf8_lossy()
+            })
+            .ok_or(BiosParseError::SystemSkuNumberNotFound),
+        "system-family" => data
+            .find_map(|system_info: SMBiosSystemInformation| system_info.family().to_utf8_lossy())
+            .ok_or(BiosParseError::SystemFamilyNotFound),
+        "baseboard-manufacturer" => data
+            .find_map(|baseboard_info: SMBiosBaseboardInformation| {
+                baseboard_info.manufacturer().to_utf8_lossy()
+            })
+            .ok_or(BiosParseError::BaseboardManufacturerNotFound),
+        "baseboard-product-name" => data
+            .find_map(|baseboard_info: SMBiosBaseboardInformation| {
+                baseboard_info.product().to_utf8_lossy()
+            })
+            .ok_or(BiosParseError::BaseboardProductNameNotFound),
+        "baseboard-version" => data
+            .find_map(|baseboard_info: SMBiosBaseboardInformation| {
+                baseboard_info.version().to_utf8_lossy()
+            })
+            .ok_or(BiosParseError::BaseboardVersionNotFound),
+        "baseboard-serial-number" => data
+            .find_map(|baseboard_info: SMBiosBaseboardInformation| {
+                baseboard_info.serial_number().to_utf8_lossy()
+            })
+            .ok_or(BiosParseError::BaseboardSerialNumberNotFound),
+        "baseboard-asset-tag" => data
+            .find_map(|baseboard_info: SMBiosBaseboardInformation| {
+                baseboard_info.asset_tag().to_utf8_lossy()
+            })
+            .ok_or(BiosParseError::BaseboardAssetTagNotFound),
+        "chassis-manufacturer" => data
+            .find_map(|chassis_info: SMBiosSystemChassisInformation| {
+                chassis_info.manufacturer().to_utf8_lossy()
+            })
+            .ok_or(BiosParseError::ChassisManufacturerNotFound),
         "chassis-type" => match data
             .find_map(|chassis_info: SMBiosSystemChassisInformation| chassis_info.chassis_type())
         {
             Some(chassis_type) => Ok(format!("{}", chassis_type)),
             None => Err(BiosParseError::ChassisTypeNotFound),
         },
-        "chassis-version" => match data.first::<SMBiosSystemChassisInformation>() {
-            Some(chassis_info) => match chassis_info.version() {
-                Ok(version) => Ok(version),
-                Err(err) => match err {
-                    SMBiosStringError::Utf8(utf8) => {
-                        Ok(String::from_utf8_lossy(utf8.as_bytes()).to_string())
-                    }
-                    _ => Err(BiosParseError::ChassisVersionNotFound),
-                },
-            },
-            None => Err(BiosParseError::ChassisVersionNotFound),
-        },
-        "chassis-serial-number" => match data.first::<SMBiosSystemChassisInformation>() {
-            Some(chassis_info) => match chassis_info.serial_number() {
-                Ok(serial_number) => Ok(serial_number),
-                Err(err) => match err {
-                    SMBiosStringError::Utf8(utf8) => {
-                        Ok(String::from_utf8_lossy(utf8.as_bytes()).to_string())
-                    }
-                    _ => Err(BiosParseError::ChassisSerialNumberNotFound),
-                },
-            },
-            None => Err(BiosParseError::ChassisSerialNumberNotFound),
-        },
-        "chassis-asset-tag" => match data.first::<SMBiosSystemChassisInformation>() {
-            Some(chassis_info) => match chassis_info.asset_tag_number() {
-                Ok(asset_tag_number) => Ok(asset_tag_number),
-                Err(err) => match err {
-                    SMBiosStringError::Utf8(utf8) => {
-                        Ok(String::from_utf8_lossy(utf8.as_bytes()).to_string())
-                    }
-                    _ => Err(BiosParseError::ChassisAssetTagNotFound),
-                },
-            },
-            None => Err(BiosParseError::ChassisAssetTagNotFound),
-        },
+        "chassis-version" => data
+            .find_map(|chassis_info: SMBiosSystemChassisInformation| {
+                chassis_info.version().to_utf8_lossy()
+            })
+            .ok_or(BiosParseError::ChassisVersionNotFound),
+        "chassis-serial-number" => data
+            .find_map(|chassis_info: SMBiosSystemChassisInformation| {
+                chassis_info.serial_number().to_utf8_lossy()
+            })
+            .ok_or(BiosParseError::ChassisSerialNumberNotFound),
+        "chassis-asset-tag" => data
+            .find_map(|chassis_info: SMBiosSystemChassisInformation| {
+                chassis_info.asset_tag_number().to_utf8_lossy()
+            })
+            .ok_or(BiosParseError::ChassisAssetTagNotFound),
         "processor-family" => match data.first::<SMBiosProcessorInformation>() {
             Some(processor_info) => match processor_info.processor_family() {
                 Some(family) => match family.value {
@@ -315,30 +179,16 @@ fn string_keyword(keyword: String, data: &SMBiosData) -> Result<String, BiosPars
             },
             None => Err(BiosParseError::ProcessorFamilyNotFound),
         },
-        "processor-manufacturer" => match data.first::<SMBiosProcessorInformation>() {
-            Some(processor_info) => match processor_info.processor_manufacturer() {
-                Ok(processor_manufacturer) => Ok(processor_manufacturer),
-                Err(err) => match err {
-                    SMBiosStringError::Utf8(utf8) => {
-                        Ok(String::from_utf8_lossy(utf8.as_bytes()).to_string())
-                    }
-                    _ => Err(BiosParseError::ProcessorManufacturerNotFound),
-                },
-            },
-            None => Err(BiosParseError::ProcessorManufacturerNotFound),
-        },
-        "processor-version" => match data.first::<SMBiosProcessorInformation>() {
-            Some(processor_info) => match processor_info.processor_version() {
-                Ok(processor_version) => Ok(processor_version),
-                Err(err) => match err {
-                    SMBiosStringError::Utf8(utf8) => {
-                        Ok(String::from_utf8_lossy(utf8.as_bytes()).to_string())
-                    }
-                    _ => Err(BiosParseError::ProcessorVersionNotFound),
-                },
-            },
-            None => Err(BiosParseError::ProcessorVersionNotFound),
-        },
+        "processor-manufacturer" => data
+            .find_map(|processor_info: SMBiosProcessorInformation| {
+                processor_info.processor_manufacturer().to_utf8_lossy()
+            })
+            .ok_or(BiosParseError::ProcessorManufacturerNotFound),
+        "processor-version" => data
+            .find_map(|processor_info: SMBiosProcessorInformation| {
+                processor_info.processor_version().to_utf8_lossy()
+            })
+            .ok_or(BiosParseError::ProcessorVersionNotFound),
         "processor-frequency" => match data
             .find_map(|processor_info: SMBiosProcessorInformation| processor_info.current_speed())
         {

--- a/src/structs/defined_struct.rs
+++ b/src/structs/defined_struct.rs
@@ -104,6 +104,8 @@ pub enum DefinedStruct<'a> {
     TpmDevice(SMBiosTpmDevice<'a>),
     /// Processor Additional Information (Type 44)
     ProcessorAdditionalInformation(SMBiosProcessorAdditionalInformation<'a>),
+    /// Firmware Inventory Information (Type 45)
+    FirmwareInventoryInformation(SMBiosFirmwareInventoryInformation<'a>),
     /// Inactive (Type 126)
     Inactive(SMBiosInactive<'a>),
     /// End-of-Table (Type 127)
@@ -272,6 +274,11 @@ impl<'a> From<&'a UndefinedStruct> for DefinedStruct<'a> {
             SMBiosProcessorAdditionalInformation::STRUCT_TYPE => {
                 DefinedStruct::ProcessorAdditionalInformation(
                     SMBiosProcessorAdditionalInformation::new(undefined_struct),
+                )
+            }
+            SMBiosFirmwareInventoryInformation::STRUCT_TYPE => {
+                DefinedStruct::FirmwareInventoryInformation(
+                    SMBiosFirmwareInventoryInformation::new(undefined_struct),
                 )
             }
             SMBiosInactive::STRUCT_TYPE => {

--- a/src/structs/defined_struct.rs
+++ b/src/structs/defined_struct.rs
@@ -106,6 +106,8 @@ pub enum DefinedStruct<'a> {
     ProcessorAdditionalInformation(SMBiosProcessorAdditionalInformation<'a>),
     /// Firmware Inventory Information (Type 45)
     FirmwareInventoryInformation(SMBiosFirmwareInventoryInformation<'a>),
+    /// String Property (Type 46)
+    StringProperty(SMBiosStringProperty<'a>),
     /// Inactive (Type 126)
     Inactive(SMBiosInactive<'a>),
     /// End-of-Table (Type 127)
@@ -280,6 +282,9 @@ impl<'a> From<&'a UndefinedStruct> for DefinedStruct<'a> {
                 DefinedStruct::FirmwareInventoryInformation(
                     SMBiosFirmwareInventoryInformation::new(undefined_struct),
                 )
+            }
+            SMBiosStringProperty::STRUCT_TYPE => {
+                DefinedStruct::StringProperty(SMBiosStringProperty::new(undefined_struct))
             }
             SMBiosInactive::STRUCT_TYPE => {
                 DefinedStruct::Inactive(SMBiosInactive::new(undefined_struct))

--- a/src/structs/types/additional_information.rs
+++ b/src/structs/types/additional_information.rs
@@ -1,4 +1,4 @@
-use crate::core::{Handle, SMBiosStringError, UndefinedStruct};
+use crate::core::{strings::*, Handle, UndefinedStruct};
 use crate::structs::SMBiosStruct;
 use serde::{ser::SerializeSeq, ser::SerializeStruct, Serialize, Serializer};
 use std::fmt;
@@ -43,7 +43,7 @@ impl<'a> AdditionalInformationEntry<'a> {
     }
 
     /// Number of the optional string to be associated with the field referenced by the _Referenced Offset_
-    pub fn string(&self) -> Result<String, SMBiosStringError> {
+    pub fn string(&self) -> SMBiosString {
         self.additional_information
             .parts()
             .get_field_string(self.entry_offset + 4)
@@ -294,10 +294,7 @@ mod tests {
                 .expect("must be entry length of 6"),
             6
         );
-        assert_eq!(
-            first_entry.string().expect("must be entry string of \"X\""),
-            "X".to_string()
-        );
+        assert_eq!(first_entry.string().to_string(), "X".to_string());
 
         assert!(iterator.next().is_none());
 

--- a/src/structs/types/additional_information.rs
+++ b/src/structs/types/additional_information.rs
@@ -1,4 +1,4 @@
-use crate::core::{Handle, UndefinedStruct};
+use crate::core::{Handle, SMBiosStringError, UndefinedStruct};
 use crate::structs::SMBiosStruct;
 use serde::{ser::SerializeSeq, ser::SerializeStruct, Serialize, Serializer};
 use std::fmt;
@@ -43,7 +43,7 @@ impl<'a> AdditionalInformationEntry<'a> {
     }
 
     /// Number of the optional string to be associated with the field referenced by the _Referenced Offset_
-    pub fn string(&self) -> Option<String> {
+    pub fn string(&self) -> Result<String, SMBiosStringError> {
         self.additional_information
             .parts()
             .get_field_string(self.entry_offset + 4)

--- a/src/structs/types/baseboard_information.rs
+++ b/src/structs/types/baseboard_information.rs
@@ -1,4 +1,4 @@
-use crate::core::{Handle, UndefinedStruct};
+use crate::core::{Handle, SMBiosStringError, UndefinedStruct};
 use crate::SMBiosStruct;
 use serde::{ser::SerializeSeq, ser::SerializeStruct, Serialize, Serializer};
 use std::fmt;
@@ -27,27 +27,27 @@ impl<'a> SMBiosStruct<'a> for SMBiosBaseboardInformation<'a> {
 
 impl<'a> SMBiosBaseboardInformation<'a> {
     ///Baseboard manufacturer
-    pub fn manufacturer(&self) -> Option<String> {
+    pub fn manufacturer(&self) -> Result<String, SMBiosStringError> {
         self.parts.get_field_string(0x04)
     }
 
     /// Baseboard product
-    pub fn product(&self) -> Option<String> {
+    pub fn product(&self) -> Result<String, SMBiosStringError> {
         self.parts.get_field_string(0x05)
     }
 
     /// Baseboard version
-    pub fn version(&self) -> Option<String> {
+    pub fn version(&self) -> Result<String, SMBiosStringError> {
         self.parts.get_field_string(0x06)
     }
 
     /// Baseboard serial number
-    pub fn serial_number(&self) -> Option<String> {
+    pub fn serial_number(&self) -> Result<String, SMBiosStringError> {
         self.parts.get_field_string(0x07)
     }
 
     /// Baseboard asset tag
-    pub fn asset_tag(&self) -> Option<String> {
+    pub fn asset_tag(&self) -> Result<String, SMBiosStringError> {
         self.parts.get_field_string(0x08)
     }
 
@@ -59,7 +59,7 @@ impl<'a> SMBiosBaseboardInformation<'a> {
     }
 
     /// This baseboard's location within the chassis (chassis is referenced by ChassisHandle).
-    pub fn location_in_chassis(&self) -> Option<String> {
+    pub fn location_in_chassis(&self) -> Result<String, SMBiosStringError> {
         self.parts.get_field_string(0x0A)
     }
 
@@ -461,17 +461,20 @@ mod tests {
             baseboard_information.product().unwrap(),
             "Surface Laptop 3".to_string()
         );
-        assert_eq!(baseboard_information.version().is_none(), true);
+        assert_eq!(baseboard_information.version().unwrap(), "".to_string());
         assert_eq!(
             baseboard_information.serial_number().unwrap(),
             "B009250100J1939B".to_string()
         );
-        assert_eq!(baseboard_information.asset_tag().is_none(), true);
+        assert_eq!(baseboard_information.asset_tag().unwrap(), "".to_string());
         assert_eq!(
             baseboard_information.feature_flags().unwrap(),
             BaseboardFeatures::from(1)
         );
-        assert_eq!(baseboard_information.location_in_chassis().is_none(), true);
+        assert_eq!(
+            baseboard_information.location_in_chassis().unwrap(),
+            "".to_string()
+        );
         assert_eq!(*baseboard_information.chassis_handle().unwrap(), 0x0F);
         assert_eq!(
             *baseboard_information.board_type().unwrap(),

--- a/src/structs/types/baseboard_information.rs
+++ b/src/structs/types/baseboard_information.rs
@@ -1,4 +1,4 @@
-use crate::core::{Handle, SMBiosStringError, UndefinedStruct};
+use crate::core::{strings::*, Handle, UndefinedStruct};
 use crate::SMBiosStruct;
 use serde::{ser::SerializeSeq, ser::SerializeStruct, Serialize, Serializer};
 use std::fmt;
@@ -27,27 +27,27 @@ impl<'a> SMBiosStruct<'a> for SMBiosBaseboardInformation<'a> {
 
 impl<'a> SMBiosBaseboardInformation<'a> {
     ///Baseboard manufacturer
-    pub fn manufacturer(&self) -> Result<String, SMBiosStringError> {
+    pub fn manufacturer(&self) -> SMBiosString {
         self.parts.get_field_string(0x04)
     }
 
     /// Baseboard product
-    pub fn product(&self) -> Result<String, SMBiosStringError> {
+    pub fn product(&self) -> SMBiosString {
         self.parts.get_field_string(0x05)
     }
 
     /// Baseboard version
-    pub fn version(&self) -> Result<String, SMBiosStringError> {
+    pub fn version(&self) -> SMBiosString {
         self.parts.get_field_string(0x06)
     }
 
     /// Baseboard serial number
-    pub fn serial_number(&self) -> Result<String, SMBiosStringError> {
+    pub fn serial_number(&self) -> SMBiosString {
         self.parts.get_field_string(0x07)
     }
 
     /// Baseboard asset tag
-    pub fn asset_tag(&self) -> Result<String, SMBiosStringError> {
+    pub fn asset_tag(&self) -> SMBiosString {
         self.parts.get_field_string(0x08)
     }
 
@@ -59,7 +59,7 @@ impl<'a> SMBiosBaseboardInformation<'a> {
     }
 
     /// This baseboard's location within the chassis (chassis is referenced by ChassisHandle).
-    pub fn location_in_chassis(&self) -> Result<String, SMBiosStringError> {
+    pub fn location_in_chassis(&self) -> SMBiosString {
         self.parts.get_field_string(0x0A)
     }
 
@@ -454,25 +454,28 @@ mod tests {
 
         // basic field tests
         assert_eq!(
-            baseboard_information.manufacturer().unwrap(),
+            baseboard_information.manufacturer().to_string(),
             "Microsoft Corporation".to_string()
         );
         assert_eq!(
-            baseboard_information.product().unwrap(),
+            baseboard_information.product().to_string(),
             "Surface Laptop 3".to_string()
         );
-        assert_eq!(baseboard_information.version().unwrap(), "".to_string());
+        assert_eq!(baseboard_information.version().to_string(), "".to_string());
         assert_eq!(
-            baseboard_information.serial_number().unwrap(),
+            baseboard_information.serial_number().to_string(),
             "B009250100J1939B".to_string()
         );
-        assert_eq!(baseboard_information.asset_tag().unwrap(), "".to_string());
+        assert_eq!(
+            baseboard_information.asset_tag().to_string(),
+            "".to_string()
+        );
         assert_eq!(
             baseboard_information.feature_flags().unwrap(),
             BaseboardFeatures::from(1)
         );
         assert_eq!(
-            baseboard_information.location_in_chassis().unwrap(),
+            baseboard_information.location_in_chassis().to_string(),
             "".to_string()
         );
         assert_eq!(*baseboard_information.chassis_handle().unwrap(), 0x0F);

--- a/src/structs/types/bios_information.rs
+++ b/src/structs/types/bios_information.rs
@@ -1,4 +1,4 @@
-use crate::core::{SMBiosStringError, UndefinedStruct};
+use crate::core::{strings::*, UndefinedStruct};
 use crate::SMBiosStruct;
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use std::fmt;
@@ -27,7 +27,7 @@ impl<'a> SMBiosStruct<'a> for SMBiosInformation<'a> {
 
 impl<'a> SMBiosInformation<'a> {
     /// BIOS vendor's name
-    pub fn vendor(&self) -> Result<String, SMBiosStringError> {
+    pub fn vendor(&self) -> SMBiosString {
         self.parts.get_field_string(0x4)
     }
 
@@ -35,7 +35,7 @@ impl<'a> SMBiosInformation<'a> {
     ///
     /// This value is a free-form string that may contain
     /// Core and OEM version information.
-    pub fn version(&self) -> Result<String, SMBiosStringError> {
+    pub fn version(&self) -> SMBiosString {
         self.parts.get_field_string(0x5)
     }
 
@@ -64,7 +64,7 @@ impl<'a> SMBiosInformation<'a> {
     ///
     /// NOTE: The mm/dd/yyyy format is required for
     /// SMBIOS version 2.3 and later.
-    pub fn release_date(&self) -> Result<String, SMBiosStringError> {
+    pub fn release_date(&self) -> SMBiosString {
         self.parts.get_field_string(0x8)
     }
 
@@ -977,11 +977,11 @@ mod tests {
         let parts = UndefinedStruct::new(&struct_type0);
         let test_struct = SMBiosInformation::new(&parts);
 
-        assert_eq!(test_struct.vendor().unwrap(), "LENOVO".to_string());
-        assert_eq!(test_struct.version().unwrap(), "S03KT33A".to_string());
+        assert_eq!(test_struct.vendor().to_string(), "LENOVO".to_string());
+        assert_eq!(test_struct.version().to_string(), "S03KT33A".to_string());
         assert_eq!(test_struct.starting_address_segment(), Some(61440));
         assert_eq!(
-            test_struct.release_date().unwrap(),
+            test_struct.release_date().to_string(),
             "08/06/2019".to_string()
         );
         assert_eq!(test_struct.rom_size(), Some(RomSize::SeeExtendedRomSize));

--- a/src/structs/types/bios_information.rs
+++ b/src/structs/types/bios_information.rs
@@ -813,7 +813,7 @@ impl BiosCharacteristicsExtension1 {
     /// Function key-initiated network service boot is supported. When function key-uninitiated
     /// network service boot is not supported, a network adapter option ROM may choose to offer
     /// this functionality on its own, thus offering this capability to legacy systems. When the
-    /// function is supported, the network adapter option ROM shall not offer this capability.'
+    /// function is supported, the network adapter option ROM shall not offer this capability.
     ///
     /// Available version 2.3.1 and later.
     pub fn fkey_initiated_network_boot_is_supported(&self) -> bool {

--- a/src/structs/types/bios_information.rs
+++ b/src/structs/types/bios_information.rs
@@ -4,6 +4,10 @@ use std::fmt;
 use std::ops::Deref;
 
 /// #  BIOS Information (Type 0)
+///
+/// Compliant with:
+/// DMTF SMBIOS Reference Specification 3.5.0 (DSP0134)
+/// Document Date: 2021-09-15
 pub struct SMBiosInformation<'a> {
     parts: &'a UndefinedStruct,
 }

--- a/src/structs/types/bios_information.rs
+++ b/src/structs/types/bios_information.rs
@@ -39,6 +39,9 @@ impl<'a> SMBiosInformation<'a> {
     /// Segment location of BIOS starting address
     /// (for example, 0E800h).
     ///
+    /// When not applicable, such as on UEFI-based systems,
+    /// this value is set to 0000h.
+    ///
     /// NOTE: The size of the runtime BIOS image can
     /// be computed by subtracting the Starting
     /// Address Segment from 10000h and
@@ -683,42 +686,42 @@ impl From<u8> for BiosCharacteristicsExtension0 {
 impl BiosCharacteristicsExtension0 {
     /// ACPI is supported.
     pub fn acpi_is_supported(&self) -> bool {
-        self.raw & 0x01 == 0x01
+        self.raw & 0b0000_0001 == 0b0000_0001
     }
 
     /// USB Legacy is supported.
     pub fn usb_legacy_is_supported(&self) -> bool {
-        self.raw & 0x02 == 0x02
+        self.raw & 0b0000_0010 == 0b0000_0010
     }
 
     /// AGP is supported.
     pub fn agp_is_supported(&self) -> bool {
-        self.raw & 0x04 == 0x04
+        self.raw & 0b0000_0100 == 0b0000_0100
     }
 
     /// I2O boot is supported.
     pub fn i2oboot_is_supported(&self) -> bool {
-        self.raw & 0x08 == 0x08
+        self.raw & 0b0000_1000 == 0b0000_1000
     }
 
     /// LS-120 SuperDisk boot is supported.
     pub fn ls120super_disk_boot_is_supported(&self) -> bool {
-        self.raw & 0x10 == 0x10
+        self.raw & 0b0001_0000 == 0b0001_0000
     }
 
     /// ATAPI ZIP drive boot is supported.
     pub fn atapi_zip_drive_boot_is_supported(&self) -> bool {
-        self.raw & 0x20 == 0x20
+        self.raw & 0b0010_0000 == 0b0010_0000
     }
 
     /// 1394 boot is supported.
     pub fn boot_1394is_supported(&self) -> bool {
-        self.raw & 0x40 == 0x40
+        self.raw & 0b0100_0000 == 0b0100_0000
     }
 
     /// Smart battery is supported.
     pub fn smart_battery_is_supported(&self) -> bool {
-        self.raw & 0x80 == 0x80
+        self.raw & 0b1000_0000 == 0b1000_0000
     }
 }
 
@@ -798,34 +801,60 @@ impl From<u8> for BiosCharacteristicsExtension1 {
 
 impl BiosCharacteristicsExtension1 {
     /// BIOS Boot Specification is supported.
+    ///
+    /// Available version 2.3.0 and later.
     pub fn bios_boot_specification_is_supported(&self) -> bool {
-        self.raw & 0x01 == 0x01
+        self.raw & 0b0000_0001 == 0b0000_0001
     }
 
     /// Function key-initiated network service boot is supported. When function key-uninitiated
     /// network service boot is not supported, a network adapter option ROM may choose to offer
     /// this functionality on its own, thus offering this capability to legacy systems. When the
-    /// function is supported, the network adapter option ROM shall not offer this capability.
+    /// function is supported, the network adapter option ROM shall not offer this capability.'
+    ///
+    /// Available version 2.3.1 and later.
     pub fn fkey_initiated_network_boot_is_supported(&self) -> bool {
-        self.raw & 0x02 == 0x02
+        self.raw & 0b0000_0010 == 0b0000_0010
     }
 
     /// Enable targeted content distribution. The manufacturer has ensured that the SMBIOS data
     /// is useful in identifying the computer for targeted delivery of model-specific software and
     /// firmware content through third-party content distribution services.
+    ///
+    /// Available version 2.4 and later.
     pub fn targeted_content_distribution_is_supported(&self) -> bool {
-        self.raw & 0x04 == 0x04
+        self.raw & 0b0000_0100 == 0b0000_0100
     }
 
     /// UEFI Specification is supported.
+    ///
+    /// Available version 2.7 and later.
     pub fn uefi_specification_is_supported(&self) -> bool {
-        self.raw & 0x08 == 0x08
+        self.raw & 0b0000_1000 == 0b0000_1000
     }
 
     /// SMBIOS table describes a virtual machine. (If this bit is not set, no inference can be made
     /// about the virtuality of the system.)
+    ///
+    /// Available version 2.7 and later.
     pub fn smbios_table_describes_avirtual_machine(&self) -> bool {
-        self.raw & 0x10 == 0x10
+        self.raw & 0b0001_0000 == 0b0001_0000
+    }
+
+    /// Manufacturing mode is supported. (Manufacturing mode is a special boot mode, not normally
+    /// available to end users, that modifies BIOS features and settings for use while the computer is being
+    /// manufactured and tested.)
+    ///
+    /// Available version 3.5 and later.
+    pub fn manufacturing_mode_is_supported(&self) -> bool {
+        self.raw & 0b0010_0000 == 0b0010_0000
+    }
+
+    /// Manufacturing mode is enabled.
+    ///
+    /// Available version 3.5 and later.
+    pub fn manufacturing_mode_is_enabled(&self) -> bool {
+        self.raw & 0b0100_0000 == 0b0100_0000
     }
 }
 
@@ -852,6 +881,14 @@ impl fmt::Debug for BiosCharacteristicsExtension1 {
             .field(
                 "smbios_table_describes_avirtual_machine",
                 &self.smbios_table_describes_avirtual_machine(),
+            )
+            .field(
+                "manufacturing_mode_is_supported",
+                &self.manufacturing_mode_is_supported(),
+            )
+            .field(
+                "manufacturing_mode_is_enabled",
+                &self.manufacturing_mode_is_enabled(),
             )
             .finish()
     }
@@ -883,6 +920,14 @@ impl Serialize for BiosCharacteristicsExtension1 {
         state.serialize_field(
             "smbios_table_describes_avirtual_machine",
             &self.smbios_table_describes_avirtual_machine(),
+        )?;
+        state.serialize_field(
+            "manufacturing_mode_is_supported",
+            &self.manufacturing_mode_is_supported(),
+        )?;
+        state.serialize_field(
+            "manufacturing_mode_is_enabled",
+            &self.manufacturing_mode_is_enabled(),
         )?;
         state.end()
     }

--- a/src/structs/types/bios_language_information.rs
+++ b/src/structs/types/bios_language_information.rs
@@ -1,4 +1,4 @@
-use crate::{SMBiosStringError, SMBiosStruct, Strings, UndefinedStruct};
+use crate::{strings::*, SMBiosStruct, UndefinedStruct};
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use std::fmt;
 use std::ops::Deref;
@@ -43,12 +43,12 @@ impl<'a> SMBiosBiosLanguageInformation<'a> {
     }
 
     /// The currently installed language.
-    pub fn current_language(&self) -> Result<String, SMBiosStringError> {
+    pub fn current_language(&self) -> SMBiosString {
         self.parts.get_field_string(0x15)
     }
 
     /// Iterable collection of the installable languages.
-    pub fn installable_langauges(&self) -> &Strings {
+    pub fn installable_langauges(&self) -> &SMBiosStringSet {
         &self.parts.strings
     }
 }
@@ -181,9 +181,7 @@ mod tests {
 
         // basic field tests
         assert_eq!(
-            bios_language_information
-                .current_language()
-                .expect("current_language field exists"),
+            bios_language_information.current_language().to_string(),
             "en|US|iso8859-1".to_string()
         );
         assert_eq!(

--- a/src/structs/types/bios_language_information.rs
+++ b/src/structs/types/bios_language_information.rs
@@ -199,15 +199,12 @@ mod tests {
         let mut string_iterator = bios_language_information
             .installable_langauges()
             .into_iter();
-        let first_string = string_iterator.next().expect("has a first string").unwrap();
-        assert_eq!(first_string, "en|US|iso8859-1".to_string());
-        let second_string = string_iterator
-            .next()
-            .expect("has a second string")
-            .unwrap();
-        assert_eq!(second_string, "hr|HR|iso8859-2".to_string());
-        let third_string = string_iterator.next().expect("has a third string").unwrap();
-        assert_eq!(third_string, "ja|JP|unicode".to_string());
+        let first_string = string_iterator.next().expect("has a first string").ok();
+        assert_eq!(first_string, Some("en|US|iso8859-1".to_string()));
+        let second_string = string_iterator.next().expect("has a second string").ok();
+        assert_eq!(second_string, Some("hr|HR|iso8859-2".to_string()));
+        let third_string = string_iterator.next().expect("has a third string").ok();
+        assert_eq!(third_string, Some("ja|JP|unicode".to_string()));
         assert!(string_iterator.next().is_none());
 
         // debug print test

--- a/src/structs/types/bios_language_information.rs
+++ b/src/structs/types/bios_language_information.rs
@@ -1,4 +1,4 @@
-use crate::{SMBiosStruct, Strings, UndefinedStruct};
+use crate::{SMBiosStringError, SMBiosStruct, Strings, UndefinedStruct};
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use std::fmt;
 use std::ops::Deref;
@@ -43,7 +43,7 @@ impl<'a> SMBiosBiosLanguageInformation<'a> {
     }
 
     /// The currently installed language.
-    pub fn current_language(&self) -> Option<String> {
+    pub fn current_language(&self) -> Result<String, SMBiosStringError> {
         self.parts.get_field_string(0x15)
     }
 

--- a/src/structs/types/bios_language_information.rs
+++ b/src/structs/types/bios_language_information.rs
@@ -201,11 +201,14 @@ mod tests {
         let mut string_iterator = bios_language_information
             .installable_langauges()
             .into_iter();
-        let first_string = string_iterator.next().expect("has a first string");
+        let first_string = string_iterator.next().expect("has a first string").unwrap();
         assert_eq!(first_string, "en|US|iso8859-1".to_string());
-        let second_string = string_iterator.next().expect("has a second string");
+        let second_string = string_iterator
+            .next()
+            .expect("has a second string")
+            .unwrap();
         assert_eq!(second_string, "hr|HR|iso8859-2".to_string());
-        let third_string = string_iterator.next().expect("has a third string");
+        let third_string = string_iterator.next().expect("has a third string").unwrap();
         assert_eq!(third_string, "ja|JP|unicode".to_string());
         assert!(string_iterator.next().is_none());
 

--- a/src/structs/types/built_in_pointing_device.rs
+++ b/src/structs/types/built_in_pointing_device.rs
@@ -11,8 +11,8 @@ use std::ops::Deref;
 /// for the system’s use.
 ///
 /// Compliant with:
-/// DMTF SMBIOS Reference Specification 3.4.0 (DSP0134)
-/// Document Date: 2020-07-17
+/// DMTF SMBIOS Reference Specification 3.5.0 (DSP0134)
+/// Document Date: 2021-09-15
 pub struct SMBiosBuiltInPointingDevice<'a> {
     parts: &'a UndefinedStruct,
 }
@@ -239,6 +239,14 @@ pub enum PointingDeviceInterface {
     BusMouseMicroDin,
     /// USB
     USB,
+    /// I2C
+    ///
+    /// Available in version 3.5.0 and later.
+    I2C,
+    /// SPI
+    ///
+    /// Available in version 3.5.0 and later.
+    SPI,
     /// A value unknown to this standard, check the raw value
     None,
 }
@@ -258,6 +266,8 @@ impl From<u8> for PointingDeviceInterfaceData {
                 0xA0 => PointingDeviceInterface::BusMouseDB9,
                 0xA1 => PointingDeviceInterface::BusMouseMicroDin,
                 0xA2 => PointingDeviceInterface::USB,
+                0xA3 => PointingDeviceInterface::I2C,
+                0xA4 => PointingDeviceInterface::SPI,
                 _ => PointingDeviceInterface::None,
             },
             raw,

--- a/src/structs/types/cache_information.rs
+++ b/src/structs/types/cache_information.rs
@@ -1,4 +1,5 @@
-use crate::{SMBiosStruct, UndefinedStruct};
+use crate::core::{SMBiosStringError, UndefinedStruct};
+use crate::SMBiosStruct;
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use std::fmt;
 use std::ops::Deref;
@@ -31,7 +32,7 @@ impl<'a> SMBiosStruct<'a> for SMBiosCacheInformation<'a> {
 
 impl<'a> SMBiosCacheInformation<'a> {
     /// String number for reference designation
-    pub fn socket_designation(&self) -> Option<String> {
+    pub fn socket_designation(&self) -> Result<String, SMBiosStringError> {
         self.parts.get_field_string(0x04)
     }
 

--- a/src/structs/types/cache_information.rs
+++ b/src/structs/types/cache_information.rs
@@ -1,4 +1,4 @@
-use crate::core::{SMBiosStringError, UndefinedStruct};
+use crate::core::{strings::*, UndefinedStruct};
 use crate::SMBiosStruct;
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use std::fmt;
@@ -32,7 +32,7 @@ impl<'a> SMBiosStruct<'a> for SMBiosCacheInformation<'a> {
 
 impl<'a> SMBiosCacheInformation<'a> {
     /// String number for reference designation
-    pub fn socket_designation(&self) -> Result<String, SMBiosStringError> {
+    pub fn socket_designation(&self) -> SMBiosString {
         self.parts.get_field_string(0x04)
     }
 

--- a/src/structs/types/cooling_device.rs
+++ b/src/structs/types/cooling_device.rs
@@ -1,4 +1,4 @@
-use crate::core::{Handle, SMBiosStringError, UndefinedStruct};
+use crate::core::{strings::*, Handle, UndefinedStruct};
 use crate::SMBiosStruct;
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use std::fmt;
@@ -73,7 +73,7 @@ impl<'a> SMBiosCoolingDevice<'a> {
     /// Additional descriptive information about the cooling device or its location
     /// This field is present in the structure only if the
     /// structure’s length is 0Fh or larger.
-    pub fn description(&self) -> Result<String, SMBiosStringError> {
+    pub fn description(&self) -> SMBiosString {
         self.parts.get_field_string(0x0E)
     }
 }
@@ -278,7 +278,7 @@ mod tests {
             RotationalSpeed::Unknown => (),
         }
         assert_eq!(
-            test_struct.description().unwrap(),
+            test_struct.description().to_string(),
             "Cooling Dev 1".to_string()
         );
     }

--- a/src/structs/types/cooling_device.rs
+++ b/src/structs/types/cooling_device.rs
@@ -1,4 +1,4 @@
-use crate::core::{Handle, UndefinedStruct};
+use crate::core::{Handle, SMBiosStringError, UndefinedStruct};
 use crate::SMBiosStruct;
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use std::fmt;
@@ -73,7 +73,7 @@ impl<'a> SMBiosCoolingDevice<'a> {
     /// Additional descriptive information about the cooling device or its location
     /// This field is present in the structure only if the
     /// structure’s length is 0Fh or larger.
-    pub fn description(&self) -> Option<String> {
+    pub fn description(&self) -> Result<String, SMBiosStringError> {
         self.parts.get_field_string(0x0E)
     }
 }
@@ -277,6 +277,9 @@ mod tests {
             RotationalSpeed::Rpm(_) => panic!("expected unknown"),
             RotationalSpeed::Unknown => (),
         }
-        assert_eq!(test_struct.description(), Some("Cooling Dev 1".to_string()));
+        assert_eq!(
+            test_struct.description().unwrap(),
+            "Cooling Dev 1".to_string()
+        );
     }
 }

--- a/src/structs/types/electrical_current_probe.rs
+++ b/src/structs/types/electrical_current_probe.rs
@@ -1,5 +1,5 @@
 use crate::SMBiosStruct;
-use crate::{SMBiosStringError, UndefinedStruct};
+use crate::{strings::*, UndefinedStruct};
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use std::fmt;
 
@@ -28,7 +28,7 @@ impl<'a> SMBiosStruct<'a> for SMBiosElectricalCurrentProbe<'a> {
 
 impl<'a> SMBiosElectricalCurrentProbe<'a> {
     ///  A string that contains additional descriptive information about the probe or its location
-    pub fn description(&self) -> Result<String, SMBiosStringError> {
+    pub fn description(&self) -> SMBiosString {
         self.parts.get_field_string(0x04)
     }
 
@@ -310,7 +310,7 @@ mod tests {
         let parts = UndefinedStruct::new(&struct_type29);
         let test_struct = SMBiosElectricalCurrentProbe::new(&parts);
 
-        assert_eq!(test_struct.description().unwrap(), "ABC".to_string());
+        assert_eq!(test_struct.description().to_string(), "ABC".to_string());
         let location_and_status = test_struct.location_and_status().unwrap();
         assert_eq!(location_and_status.status, CurrentProbeStatus::OK);
         assert_eq!(

--- a/src/structs/types/electrical_current_probe.rs
+++ b/src/structs/types/electrical_current_probe.rs
@@ -1,4 +1,5 @@
-use crate::{SMBiosStruct, UndefinedStruct};
+use crate::SMBiosStruct;
+use crate::{SMBiosStringError, UndefinedStruct};
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use std::fmt;
 
@@ -27,7 +28,7 @@ impl<'a> SMBiosStruct<'a> for SMBiosElectricalCurrentProbe<'a> {
 
 impl<'a> SMBiosElectricalCurrentProbe<'a> {
     ///  A string that contains additional descriptive information about the probe or its location
-    pub fn description(&self) -> Option<String> {
+    pub fn description(&self) -> Result<String, SMBiosStringError> {
         self.parts.get_field_string(0x04)
     }
 
@@ -309,7 +310,7 @@ mod tests {
         let parts = UndefinedStruct::new(&struct_type29);
         let test_struct = SMBiosElectricalCurrentProbe::new(&parts);
 
-        assert_eq!(test_struct.description(), Some("ABC".to_string()));
+        assert_eq!(test_struct.description().unwrap(), "ABC".to_string());
         let location_and_status = test_struct.location_and_status().unwrap();
         assert_eq!(location_and_status.status, CurrentProbeStatus::OK);
         assert_eq!(

--- a/src/structs/types/firmware_inventory_information.rs
+++ b/src/structs/types/firmware_inventory_information.rs
@@ -1,4 +1,4 @@
-use crate::core::{Handle, SMBiosStringError, UndefinedStruct};
+use crate::core::{strings::*, Handle, UndefinedStruct};
 use crate::SMBiosStruct;
 use serde::{ser::SerializeSeq, ser::SerializeStruct, Serialize, Serializer};
 use std::fmt;
@@ -40,14 +40,14 @@ impl<'a> SMBiosFirmwareInventoryInformation<'a> {
     /// Firmware Component Name
     ///
     /// EXAMPLE: 'BMC Firmware',0
-    pub fn firmware_component_name(&self) -> Result<String, SMBiosStringError> {
+    pub fn firmware_component_name(&self) -> SMBiosString {
         self.parts.get_field_string(0x04)
     }
 
     /// Firmware Version
     ///
     /// The format of this value is defined by _version_format_
-    pub fn firmware_version(&self) -> Result<String, SMBiosStringError> {
+    pub fn firmware_version(&self) -> SMBiosString {
         self.parts.get_field_string(0x05)
     }
 
@@ -61,7 +61,7 @@ impl<'a> SMBiosFirmwareInventoryInformation<'a> {
     /// Firmware ID
     ///
     /// The format of this value is defined by _firmware_id_format_
-    pub fn firmware_id(&self) -> Result<String, SMBiosStringError> {
+    pub fn firmware_id(&self) -> SMBiosString {
         self.parts.get_field_string(0x07)
     }
 
@@ -73,19 +73,19 @@ impl<'a> SMBiosFirmwareInventoryInformation<'a> {
     }
 
     /// Release Date
-    pub fn release_date(&self) -> Result<String, SMBiosStringError> {
+    pub fn release_date(&self) -> SMBiosString {
         self.parts.get_field_string(0x09)
     }
 
     /// Manufacturer
-    pub fn manufacturer(&self) -> Result<String, SMBiosStringError> {
+    pub fn manufacturer(&self) -> SMBiosString {
         self.parts.get_field_string(0x0A)
     }
 
     /// Lowest Supported Firmware Version
     ///
     /// The format of this value is defined by _version_format_
-    pub fn lowest_supported_firmware_version(&self) -> Result<String, SMBiosStringError> {
+    pub fn lowest_supported_firmware_version(&self) -> SMBiosString {
         self.parts.get_field_string(0x0B)
     }
 
@@ -694,11 +694,13 @@ mod tests {
         assert_eq!(
             firmware_inventory_information
                 .firmware_component_name()
-                .unwrap(),
+                .to_string(),
             "BMC Firmware".to_string()
         );
         assert_eq!(
-            firmware_inventory_information.firmware_version().unwrap(),
+            firmware_inventory_information
+                .firmware_version()
+                .to_string(),
             "1.45.455b66-rev4".to_string()
         );
         assert_eq!(
@@ -709,7 +711,7 @@ mod tests {
             VersionFormat::FreeForm
         );
         assert_eq!(
-            firmware_inventory_information.firmware_id().unwrap(),
+            firmware_inventory_information.firmware_id().to_string(),
             "35EQP72B".to_string()
         );
         assert_eq!(
@@ -720,17 +722,17 @@ mod tests {
             FirmwareIdFormat::FreeForm
         );
         assert_eq!(
-            firmware_inventory_information.release_date().unwrap(),
+            firmware_inventory_information.release_date().to_string(),
             "2021-05-15T04:14:33+06:00".to_string()
         );
         assert_eq!(
-            firmware_inventory_information.manufacturer().unwrap(),
+            firmware_inventory_information.manufacturer().to_string(),
             "Apple".to_string()
         );
         assert_eq!(
             firmware_inventory_information
                 .lowest_supported_firmware_version()
-                .unwrap(),
+                .to_string(),
             "1.23.456b78-rev9".to_string()
         );
         match firmware_inventory_information.image_size().unwrap() {

--- a/src/structs/types/firmware_inventory_information.rs
+++ b/src/structs/types/firmware_inventory_information.rs
@@ -1,0 +1,777 @@
+use crate::core::{Handle, UndefinedStruct};
+use crate::SMBiosStruct;
+use serde::{ser::SerializeSeq, ser::SerializeStruct, Serialize, Serializer};
+use std::fmt;
+use std::ops::Deref;
+
+/// # Firmware Inventory Information (Type 45)
+///
+/// The information in this structure defines an inventory of firmware components in the system. This can
+/// include firmware components such as BIOS, BMC, as well as firmware for other devices in the system.
+///
+/// The information can be used by software to display the firmware inventory in a uniform manner. It can
+/// also be used by a management controller, such as a BMC, for remote system management. This
+/// structure is not intended to replace other standard programmatic interfaces for firmware updates.
+///
+/// One Type 45 structure is provided for each firmware component.
+///
+/// NOTE: This structure type was added in version 3.5 of this specification.
+///
+/// Compliant with:
+/// DMTF SMBIOS Reference Specification 3.5.0 (DSP0134)
+/// Document Date: 2021-09-15
+pub struct SMBiosFirmwareInventoryInformation<'a> {
+    parts: &'a UndefinedStruct,
+}
+
+impl<'a> SMBiosStruct<'a> for SMBiosFirmwareInventoryInformation<'a> {
+    const STRUCT_TYPE: u8 = 45u8;
+
+    fn new(parts: &'a UndefinedStruct) -> Self {
+        Self { parts }
+    }
+
+    fn parts(&self) -> &'a UndefinedStruct {
+        self.parts
+    }
+}
+
+impl<'a> SMBiosFirmwareInventoryInformation<'a> {
+    /// Firmware Component Name
+    ///
+    /// EXAMPLE: 'BMC Firmware',0
+    pub fn firmware_component_name(&self) -> Option<String> {
+        self.parts.get_field_string(0x04)
+    }
+
+    /// Firmware Version
+    ///
+    /// The format of this value is defined by _version_format_
+    pub fn firmware_version(&self) -> Option<String> {
+        self.parts.get_field_string(0x05)
+    }
+
+    /// Version Format
+    pub fn version_format(&self) -> Option<VersionFormatData> {
+        self.parts
+            .get_field_byte(0x06)
+            .map(|raw| VersionFormatData::from(raw))
+    }
+
+    /// Firmware ID
+    ///
+    /// The format of this value is defined by _firmware_id_format_
+    pub fn firmware_id(&self) -> Option<String> {
+        self.parts.get_field_string(0x07)
+    }
+
+    /// Firmware ID Format
+    pub fn firmware_id_format(&self) -> Option<FirmwareIdFormatData> {
+        self.parts
+            .get_field_byte(0x08)
+            .map(|raw| FirmwareIdFormatData::from(raw))
+    }
+
+    /// Release Date
+    pub fn release_date(&self) -> Option<String> {
+        self.parts.get_field_string(0x09)
+    }
+
+    /// Manufacturer
+    pub fn manufacturer(&self) -> Option<String> {
+        self.parts.get_field_string(0x0A)
+    }
+
+    /// Lowest Supported Firmware Version
+    pub fn lowest_supported_firmware_version(&self) -> Option<String> {
+        self.parts.get_field_string(0x0B)
+    }
+
+    /// Image Size
+    ///
+    /// Size of the firmware image that is currently programmed
+    /// in the device, in bytes. If the Firmware Image Size is
+    /// unknown, the field is set to FirmwareImageSize::Unknown.
+    pub fn image_size(&self) -> Option<FirmwareImageSize> {
+        self.parts
+            .get_field_qword(0x0C)
+            .map(|raw| FirmwareImageSize::from(raw))
+    }
+
+    /// Firmware characteristics information.
+    pub fn characteristics(&self) -> Option<FirmwareInventoryCharacteristics> {
+        self.parts
+            .get_field_word(0x14)
+            .map(|raw| FirmwareInventoryCharacteristics::from(raw))
+    }
+
+    /// Firmware state information.
+    pub fn state(&self) -> Option<FirmwareInventoryStateInformationData> {
+        self.parts
+            .get_field_byte(0x16)
+            .map(|raw| FirmwareInventoryStateInformationData::from(raw))
+    }
+
+    /// Defines how many Associated Component Handles are associated with this firmware.
+    pub fn number_of_associated_components(&self) -> Option<u8> {
+        self.parts.get_field_byte(0x17)
+    }
+
+    /// Lists the SMBIOS structure handles that are associated
+    /// with this firmware, if any.
+    ///
+    /// Value of _number_of_associated_components_ field (n) defines the count.
+    ///
+    /// NOTE: This list may contain zero or more handles to any
+    /// SMBIOS structure that represents a device with a
+    /// firmware component.
+    pub fn associated_component_handle_iterator(&'a self) -> AssociatedComponentHandleIterator<'a> {
+        AssociatedComponentHandleIterator::new(self)
+    }
+}
+
+impl fmt::Debug for SMBiosFirmwareInventoryInformation<'_> {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.debug_struct(std::any::type_name::<SMBiosFirmwareInventoryInformation<'_>>())
+            .field("header", &self.parts.header)
+            .field("firmware_component_name", &self.firmware_component_name())
+            .field("firmware_version", &self.firmware_version())
+            .field("version_format", &self.version_format())
+            .field("firmware_id", &self.firmware_id())
+            .field("firmware_id_format", &self.firmware_id_format())
+            .field("release_date", &self.release_date())
+            .field("manufacturer", &self.manufacturer())
+            .field(
+                "lowest_supported_firmware_version",
+                &self.lowest_supported_firmware_version(),
+            )
+            .field("image_size", &self.image_size())
+            .field("characteristics", &self.characteristics())
+            .field("state", &self.state())
+            .field(
+                "number_of_associated_components",
+                &self.number_of_associated_components(),
+            )
+            .field(
+                "associated_component_handle_iterator",
+                &self.associated_component_handle_iterator(),
+            )
+            .finish()
+    }
+}
+
+impl Serialize for SMBiosFirmwareInventoryInformation<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut state = serializer.serialize_struct("SMBiosFirmwareInventoryInformation", 12)?;
+        state.serialize_field("header", &self.parts.header)?;
+        state.serialize_field("firmware_component_name", &self.firmware_component_name())?;
+        state.serialize_field("firmware_version", &self.firmware_version())?;
+        state.serialize_field("version_format", &self.version_format())?;
+        state.serialize_field("firmware_id", &self.firmware_id())?;
+        state.serialize_field("firmware_id_format", &self.firmware_id_format())?;
+        state.serialize_field("release_date", &self.release_date())?;
+        state.serialize_field("manufacturer", &self.manufacturer())?;
+        state.serialize_field(
+            "lowest_supported_firmware_version",
+            &self.lowest_supported_firmware_version(),
+        )?;
+        state.serialize_field("image_size", &self.image_size())?;
+        state.serialize_field("characteristics", &self.characteristics())?;
+        state.serialize_field("state", &self.state())?;
+        state.serialize_field(
+            "number_of_associated_components",
+            &self.number_of_associated_components(),
+        )?;
+        state.serialize_field(
+            "associated_component_handle_iterator",
+            &self.associated_component_handle_iterator(),
+        )?;
+        state.end()
+    }
+}
+
+/// # Size of Image in Bytes
+#[derive(Serialize, Debug)]
+pub enum FirmwareImageSize {
+    /// Image Size is Unknown
+    Unknown,
+    /// Size of Image (bytes)
+    Bytes(u64),
+}
+
+impl From<u64> for FirmwareImageSize {
+    fn from(raw: u64) -> Self {
+        match raw {
+            0xFFFFFFFFFFFFFFFF => FirmwareImageSize::Unknown,
+            _ => FirmwareImageSize::Bytes(raw),
+        }
+    }
+}
+
+/// # Version Format Data of [SMBiosFirmwareInventoryInformation].
+pub struct VersionFormatData {
+    /// Raw value
+    ///
+    /// _raw_ is most useful when _value_ is None.
+    /// This is most likely to occur when the standard was updated but
+    /// this library code has not been updated to match the current
+    /// standard.
+    pub raw: u8,
+    /// The contained [VersionFormat] value
+    pub value: VersionFormat,
+}
+
+impl fmt::Debug for VersionFormatData {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.debug_struct(std::any::type_name::<VersionFormatData>())
+            .field("raw", &self.raw)
+            .field("value", &self.value)
+            .finish()
+    }
+}
+
+impl Serialize for VersionFormatData {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut state = serializer.serialize_struct("VersionFormatData", 2)?;
+        state.serialize_field("raw", &self.raw)?;
+        state.serialize_field("value", &self.value)?;
+        state.end()
+    }
+}
+
+impl fmt::Display for VersionFormatData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.value {
+            VersionFormat::None => write!(f, "{}", &self.raw),
+            _ => write!(f, "{:?}", &self.value),
+        }
+    }
+}
+
+impl Deref for VersionFormatData {
+    type Target = VersionFormat;
+
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
+impl From<u8> for VersionFormatData {
+    fn from(raw: u8) -> Self {
+        VersionFormatData {
+            value: match raw {
+                0x00 => VersionFormat::FreeForm,
+                0x01 => VersionFormat::MajorMinor,
+                0x02 => VersionFormat::HexidecimalString32,
+                0x03 => VersionFormat::HexidecimalString64,
+                _ => match raw & 0x80 {
+                    0x80 => VersionFormat::VendorOemSpecific,
+                    _ => VersionFormat::None,
+                },
+            },
+            raw,
+        }
+    }
+}
+
+/// # Version Format of [SMBiosFirmwareInventoryInformation]
+#[derive(Serialize, Debug, PartialEq, Eq)]
+pub enum VersionFormat {
+    /// The format is a free-form string that is implementation specific.
+    ///
+    /// EXAMPLE: '1.45.455b66-rev4',0
+    FreeForm,
+    /// The format is “MAJOR.MINOR”, where MAJOR and MINOR are decimal string representations of the
+    /// numeric values of the major/minor version numbers.
+    ///
+    /// EXAMPLE: '1.45',0
+    MajorMinor,
+    /// The format is a hexadecimal string representation of the 32-bit numeric value of the version, in the
+    /// format of "0xhhhhhhhh". Each h represents a hexadecimal digit (0-f).
+    ///
+    /// EXAMPLE: '0x0001002d',0
+    HexidecimalString32,
+    /// The format is a hexadecimal string representation of the 64-bit numeric value of the version, in the
+    /// format of "0xhhhhhhhhhhhhhhhh". Each h represents a hexadecimal digit (0-f).
+    ///
+    /// EXAMPLE: '0x000000010000002d',0
+    HexidecimalString64,
+    /// BIOS Vendor/OEM-specific
+    VendorOemSpecific,
+    /// A value unknown to this standard, check the raw value
+    None,
+}
+
+/// # Firmware Id Format Data of [SMBiosFirmwareInventoryInformation].
+pub struct FirmwareIdFormatData {
+    /// Raw value
+    ///
+    /// _raw_ is most useful when _value_ is None.
+    /// This is most likely to occur when the standard was updated but
+    /// this library code has not been updated to match the current
+    /// standard.
+    pub raw: u8,
+    /// The contained [FirmwareIdFormat] value
+    pub value: FirmwareIdFormat,
+}
+
+impl fmt::Debug for FirmwareIdFormatData {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.debug_struct(std::any::type_name::<FirmwareIdFormatData>())
+            .field("raw", &self.raw)
+            .field("value", &self.value)
+            .finish()
+    }
+}
+
+impl Serialize for FirmwareIdFormatData {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut state = serializer.serialize_struct("FirmwareIdFormatData", 2)?;
+        state.serialize_field("raw", &self.raw)?;
+        state.serialize_field("value", &self.value)?;
+        state.end()
+    }
+}
+
+impl fmt::Display for FirmwareIdFormatData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.value {
+            FirmwareIdFormat::None => write!(f, "{}", &self.raw),
+            _ => write!(f, "{:?}", &self.value),
+        }
+    }
+}
+
+impl Deref for FirmwareIdFormatData {
+    type Target = FirmwareIdFormat;
+
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
+impl From<u8> for FirmwareIdFormatData {
+    fn from(raw: u8) -> Self {
+        FirmwareIdFormatData {
+            value: match raw {
+                0x00 => FirmwareIdFormat::FreeForm,
+                0x01 => FirmwareIdFormat::UefiGuid,
+                _ => match raw & 0x80 {
+                    0x80 => FirmwareIdFormat::VendorOemSpecific,
+                    _ => FirmwareIdFormat::None,
+                },
+            },
+            raw,
+        }
+    }
+}
+
+/// # Firmware Id Format of [SMBiosFirmwareInventoryInformation]
+#[derive(Serialize, Debug, PartialEq, Eq)]
+pub enum FirmwareIdFormat {
+    /// The format is a free-form string that is implementation specific.
+    ///
+    /// EXAMPLE: '35EQP72B',0
+    FreeForm,
+    /// The format is a string representation of the UEFI ESRT FwClass GUID or the UEFI Firmware
+    /// Management Protocol ImageTypeId, as defined by the UEFI Specification. To represent the GUID, the
+    /// string is formatted using the 36-character UUID string format specified in RFC4122: "xxxxxxxx-xxxxxxxx-xxxx-xxxxxxxxxxxx." Each x represents a hexadecimal digit (0-F).
+    ///
+    /// EXAMPLE: '1624a9df-5e13-47fc-874a-df3aff143089',0
+    UefiGuid,
+    /// BIOS Vendor/OEM-specific
+    VendorOemSpecific,
+    /// A value unknown to this standard, check the raw value
+    None,
+}
+
+/// # Firmware Inventory Characteristics of [SMBiosFirmwareInventoryInformation]
+#[derive(PartialEq, Eq)]
+pub struct FirmwareInventoryCharacteristics {
+    /// Raw value
+    ///
+    /// _raw_ is useful when there are values not yet defiend.
+    /// This is most likely to occur when the standard was updated but
+    /// this library code has not been updated to match the current
+    /// standard.
+    pub raw: u16,
+}
+
+impl Deref for FirmwareInventoryCharacteristics {
+    type Target = u16;
+
+    fn deref(&self) -> &Self::Target {
+        &self.raw
+    }
+}
+
+impl From<u16> for FirmwareInventoryCharacteristics {
+    fn from(raw: u16) -> Self {
+        FirmwareInventoryCharacteristics { raw }
+    }
+}
+
+impl FirmwareInventoryCharacteristics {
+    /// Updatable
+    ///
+    /// This firmware can be updated by software.
+    pub fn updatable(&self) -> bool {
+        self.raw & 0b0000_0000_0000_0001 == 0b0000_0000_0000_0001
+    }
+
+    /// Write-Protect
+    ///
+    /// This firmware is in a write-protected state.
+    pub fn write_protect(&self) -> bool {
+        self.raw & 0b0000_0000_0000_0010 == 0b0000_0000_0000_0010
+    }
+}
+
+impl fmt::Debug for FirmwareInventoryCharacteristics {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.debug_struct(std::any::type_name::<FirmwareInventoryCharacteristics>())
+            .field("raw", &self.raw)
+            .field("updatable", &self.updatable())
+            .field("write_protect", &self.write_protect())
+            .finish()
+    }
+}
+
+impl Serialize for FirmwareInventoryCharacteristics {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut state = serializer.serialize_struct("FirmwareInventoryCharacteristics", 6)?;
+        state.serialize_field("raw", &self.raw)?;
+        state.serialize_field("updatable", &self.updatable())?;
+        state.serialize_field("write_protect", &self.write_protect())?;
+        state.end()
+    }
+}
+
+/// # Firmware Inventory State Information Data of [SMBiosFirmwareInventoryInformation].
+pub struct FirmwareInventoryStateInformationData {
+    /// Raw value
+    ///
+    /// _raw_ is most useful when _value_ is None.
+    /// This is most likely to occur when the standard was updated but
+    /// this library code has not been updated to match the current
+    /// standard.
+    pub raw: u8,
+    /// The contained [FirmwareInventoryStateInformation] value
+    pub value: FirmwareInventoryStateInformation,
+}
+
+impl fmt::Debug for FirmwareInventoryStateInformationData {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.debug_struct(std::any::type_name::<FirmwareInventoryStateInformationData>())
+            .field("raw", &self.raw)
+            .field("value", &self.value)
+            .finish()
+    }
+}
+
+impl Serialize for FirmwareInventoryStateInformationData {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut state = serializer.serialize_struct("FirmwareInventoryStateInformationData", 2)?;
+        state.serialize_field("raw", &self.raw)?;
+        state.serialize_field("value", &self.value)?;
+        state.end()
+    }
+}
+
+impl fmt::Display for FirmwareInventoryStateInformationData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.value {
+            FirmwareInventoryStateInformation::None => write!(f, "{}", &self.raw),
+            _ => write!(f, "{:?}", &self.value),
+        }
+    }
+}
+
+impl Deref for FirmwareInventoryStateInformationData {
+    type Target = FirmwareInventoryStateInformation;
+
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
+impl From<u8> for FirmwareInventoryStateInformationData {
+    fn from(raw: u8) -> Self {
+        FirmwareInventoryStateInformationData {
+            value: match raw {
+                0x01 => FirmwareInventoryStateInformation::Other,
+                0x02 => FirmwareInventoryStateInformation::Unknown,
+                0x03 => FirmwareInventoryStateInformation::Disabled,
+                0x04 => FirmwareInventoryStateInformation::Enabled,
+                0x05 => FirmwareInventoryStateInformation::Absent,
+                0x06 => FirmwareInventoryStateInformation::StandbyOffline,
+                0x07 => FirmwareInventoryStateInformation::StandbySpare,
+                0x08 => FirmwareInventoryStateInformation::UnavailableOffline,
+                _ => FirmwareInventoryStateInformation::None,
+            },
+            raw,
+        }
+    }
+}
+
+/// # Firmware Inventory State Information of [SMBiosFirmwareInventoryInformation]
+#[derive(Serialize, Debug, PartialEq, Eq)]
+pub enum FirmwareInventoryStateInformation {
+    /// Other
+    Other,
+    /// Unknown
+    Unknown,
+    /// Disabled
+    ///
+    /// This firmware component is disabled
+    Disabled,
+    /// Enabled
+    ///
+    /// This firmware component is enabled
+    Enabled,
+    /// Absent
+    ///
+    /// This firmware component is either not present or not detected
+    Absent,
+    /// Standby Offline
+    ///
+    /// This firmware is enabled but awaits an external action to activate it
+    StandbyOffline,
+    /// Standby Spare
+    ///
+    /// This firmware is part of a redundancy set and awaits a failover or other external action to
+    /// activate it
+    StandbySpare,
+    /// Unavailable Offline
+    ///
+    /// This firmware component is present but cannot be used
+    UnavailableOffline,
+    /// A value unknown to this standard, check the raw value
+    None,
+}
+
+/// # Associated Component Handle Iterator
+///
+/// Iterates over the associated component handles contained within the [SMBiosFirmwareInventoryInformation] structure
+pub struct AssociatedComponentHandleIterator<'a> {
+    data: &'a SMBiosFirmwareInventoryInformation<'a>,
+    current_index: usize,
+    current_entry: u8,
+    number_of_associated_components: u8,
+}
+
+impl<'a> AssociatedComponentHandleIterator<'a> {
+    const HANDLES_OFFSET: usize = 0x18usize;
+
+    /// Creates an instance of the associated component handle iterator.
+    pub fn new(data: &'a SMBiosFirmwareInventoryInformation<'a>) -> Self {
+        AssociatedComponentHandleIterator {
+            data: data,
+            current_index: Self::HANDLES_OFFSET,
+            current_entry: 0,
+            number_of_associated_components: data.number_of_associated_components().unwrap_or(0),
+        }
+    }
+
+    fn reset(&mut self) {
+        self.current_index = Self::HANDLES_OFFSET;
+        self.current_entry = 0;
+    }
+}
+
+impl<'a> IntoIterator for &'a AssociatedComponentHandleIterator<'a> {
+    type Item = Handle;
+    type IntoIter = AssociatedComponentHandleIterator<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        AssociatedComponentHandleIterator {
+            data: self.data,
+            current_index: AssociatedComponentHandleIterator::HANDLES_OFFSET,
+            current_entry: 0,
+            number_of_associated_components: self
+                .data
+                .number_of_associated_components()
+                .unwrap_or(0),
+        }
+    }
+}
+
+impl<'a> Iterator for AssociatedComponentHandleIterator<'a> {
+    type Item = Handle;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.current_entry == self.number_of_associated_components {
+            self.reset();
+            return None;
+        }
+
+        match self.data.parts().get_field_handle(self.current_index) {
+            Some(current_handle) => {
+                self.current_index = self.current_index + Handle::SIZE;
+                self.current_entry = self.current_entry + 1;
+                Some(current_handle)
+            }
+            None => {
+                self.reset();
+                None
+            }
+        }
+    }
+}
+
+impl<'a> fmt::Debug for AssociatedComponentHandleIterator<'a> {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.debug_list().entries(self.into_iter()).finish()
+    }
+}
+
+impl<'a> Serialize for AssociatedComponentHandleIterator<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let handles: Vec<Handle> = self.into_iter().collect();
+        let mut seq = serializer.serialize_seq(Some(handles.len()))?;
+        for e in handles {
+            seq.serialize_element(&e)?;
+        }
+        seq.end()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_firmware_inventory_information() {
+        let firmware_inventory_information_bytes = vec![
+            // struct_type(45), length(0x1A), handle(0x10)
+            0x2D, 0x1A, 0x10, 0x00,
+            // firmware_component_name(1), firmware_version(2), version_format (FreeForm - 0), firmware_id(3), firmware_id_format (FreeForm - 0), release_date(4), manufacturer(5), lowest_supported_firmware_version(6)
+            0x01, 0x02, 0x00, 0x03, 0x00, 0x04, 0x05, 0x06,
+            // image_size(0xFFFFFFFFFFFFFFFF), characteristics(0x0001), state(StandbySpare - 0x07), number_of_components(1)
+            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01, 0x00, 0x07, 0x01,
+            // handle[0] == 0x0005
+            0x05, 0x00, // firmware_component_name: "BMC Firmware" (1)
+            b'B', b'M', b'C', b' ', b'F', b'i', b'r', b'm', b'w', b'a', b'r', b'e', 0x00,
+            // firmware_version: "1.45.455b66-rev4" (2)
+            b'1', b'.', b'4', b'5', b'.', b'4', b'5', b'5', b'b', b'6', b'6', b'-', b'r', b'e',
+            b'v', b'4', 0x00, // firmware_id: "35EQP72B" (3)
+            b'3', b'5', b'E', b'Q', b'P', b'7', b'2', b'B', 0x00,
+            // release_date: "2021-05-15T04:14:33+06:00" (4)
+            b'2', b'0', b'2', b'1', b'-', b'0', b'5', b'-', b'1', b'5', b'T', b'0', b'4', b':',
+            b'1', b'4', b':', b'3', b'3', b'+', b'0', b'6', b':', b'0', b'0', 0x00,
+            // manufacturer: "Apple" (5)
+            b'A', b'p', b'p', b'l', b'e', 0x00,
+            // lowest_supported_firmware_version: "1.23.456b78-rev9" (6)
+            b'1', b'.', b'2', b'3', b'.', b'4', b'5', b'6', b'b', b'7', b'8', b'-', b'r', b'e',
+            b'v', b'9', 0x00, // end of structure
+            0x00,
+        ];
+
+        let parts = UndefinedStruct::new(&firmware_inventory_information_bytes);
+        let firmware_inventory_information = SMBiosFirmwareInventoryInformation::new(&parts);
+
+        // basic field tests
+        assert_eq!(
+            firmware_inventory_information
+                .firmware_component_name()
+                .unwrap(),
+            "BMC Firmware".to_string()
+        );
+        assert_eq!(
+            firmware_inventory_information.firmware_version().unwrap(),
+            "1.45.455b66-rev4".to_string()
+        );
+        assert_eq!(
+            firmware_inventory_information
+                .version_format()
+                .unwrap()
+                .value,
+            VersionFormat::FreeForm
+        );
+        assert_eq!(
+            firmware_inventory_information.firmware_id().unwrap(),
+            "35EQP72B".to_string()
+        );
+        assert_eq!(
+            firmware_inventory_information
+                .firmware_id_format()
+                .unwrap()
+                .value,
+            FirmwareIdFormat::FreeForm
+        );
+        assert_eq!(
+            firmware_inventory_information.release_date().unwrap(),
+            "2021-05-15T04:14:33+06:00".to_string()
+        );
+        assert_eq!(
+            firmware_inventory_information.manufacturer().unwrap(),
+            "Apple".to_string()
+        );
+        assert_eq!(
+            firmware_inventory_information
+                .lowest_supported_firmware_version()
+                .unwrap(),
+            "1.23.456b78-rev9".to_string()
+        );
+        match firmware_inventory_information.image_size().unwrap() {
+            FirmwareImageSize::Unknown => (),
+            FirmwareImageSize::Bytes(_) => panic!("expected unknown"),
+        }
+        assert_eq!(
+            firmware_inventory_information
+                .characteristics()
+                .unwrap()
+                .updatable(),
+            true
+        );
+        assert_eq!(
+            firmware_inventory_information.state().unwrap().value,
+            FirmwareInventoryStateInformation::StandbySpare
+        );
+        assert_eq!(
+            firmware_inventory_information
+                .number_of_associated_components()
+                .unwrap(),
+            1u8
+        );
+
+        let mut iterator = firmware_inventory_information.associated_component_handle_iterator();
+
+        let first_entry = iterator.next().expect("has a first entry");
+        assert_eq!(*first_entry, 0x0005);
+
+        assert!(iterator.next().is_none());
+
+        let mut counter = 0;
+
+        for _entry in firmware_inventory_information.associated_component_handle_iterator() {
+            counter = counter + 1;
+        }
+
+        assert_eq!(counter, 1);
+
+        // debug print test
+        println!(
+            "firmware_inventory_information: {:?}",
+            firmware_inventory_information
+        );
+    }
+}

--- a/src/structs/types/firmware_inventory_information.rs
+++ b/src/structs/types/firmware_inventory_information.rs
@@ -1,4 +1,4 @@
-use crate::core::{Handle, UndefinedStruct};
+use crate::core::{Handle, SMBiosStringError, UndefinedStruct};
 use crate::SMBiosStruct;
 use serde::{ser::SerializeSeq, ser::SerializeStruct, Serialize, Serializer};
 use std::fmt;
@@ -40,14 +40,14 @@ impl<'a> SMBiosFirmwareInventoryInformation<'a> {
     /// Firmware Component Name
     ///
     /// EXAMPLE: 'BMC Firmware',0
-    pub fn firmware_component_name(&self) -> Option<String> {
+    pub fn firmware_component_name(&self) -> Result<String, SMBiosStringError> {
         self.parts.get_field_string(0x04)
     }
 
     /// Firmware Version
     ///
     /// The format of this value is defined by _version_format_
-    pub fn firmware_version(&self) -> Option<String> {
+    pub fn firmware_version(&self) -> Result<String, SMBiosStringError> {
         self.parts.get_field_string(0x05)
     }
 
@@ -61,7 +61,7 @@ impl<'a> SMBiosFirmwareInventoryInformation<'a> {
     /// Firmware ID
     ///
     /// The format of this value is defined by _firmware_id_format_
-    pub fn firmware_id(&self) -> Option<String> {
+    pub fn firmware_id(&self) -> Result<String, SMBiosStringError> {
         self.parts.get_field_string(0x07)
     }
 
@@ -73,17 +73,19 @@ impl<'a> SMBiosFirmwareInventoryInformation<'a> {
     }
 
     /// Release Date
-    pub fn release_date(&self) -> Option<String> {
+    pub fn release_date(&self) -> Result<String, SMBiosStringError> {
         self.parts.get_field_string(0x09)
     }
 
     /// Manufacturer
-    pub fn manufacturer(&self) -> Option<String> {
+    pub fn manufacturer(&self) -> Result<String, SMBiosStringError> {
         self.parts.get_field_string(0x0A)
     }
 
     /// Lowest Supported Firmware Version
-    pub fn lowest_supported_firmware_version(&self) -> Option<String> {
+    ///
+    /// The format of this value is defined by _version_format_
+    pub fn lowest_supported_firmware_version(&self) -> Result<String, SMBiosStringError> {
         self.parts.get_field_string(0x0B)
     }
 

--- a/src/structs/types/group_associations.rs
+++ b/src/structs/types/group_associations.rs
@@ -1,4 +1,4 @@
-use crate::core::{Handle, UndefinedStruct};
+use crate::core::{Handle, SMBiosStringError, UndefinedStruct};
 use crate::SMBiosStruct;
 use serde::{ser::SerializeSeq, ser::SerializeStruct, Serialize, Serializer};
 use std::fmt;
@@ -30,7 +30,7 @@ impl<'a> SMBiosStruct<'a> for SMBiosGroupAssociations<'a> {
 
 impl<'a> SMBiosGroupAssociations<'a> {
     /// A string describing the group
-    pub fn group_name(&self) -> Option<String> {
+    pub fn group_name(&self) -> Result<String, SMBiosStringError> {
         self.parts.get_field_string(0x4)
     }
 
@@ -246,8 +246,8 @@ mod tests {
         println!("{:?}", test_struct);
 
         assert_eq!(
-            test_struct.group_name(),
-            Some("Firmware Version Info".to_string())
+            test_struct.group_name().unwrap(),
+            "Firmware Version Info".to_string()
         );
         let mut iterator = test_struct.item_iterator().into_iter();
         let first_item = iterator.next().unwrap();

--- a/src/structs/types/group_associations.rs
+++ b/src/structs/types/group_associations.rs
@@ -1,4 +1,4 @@
-use crate::core::{Handle, SMBiosStringError, UndefinedStruct};
+use crate::core::{strings::*, Handle, UndefinedStruct};
 use crate::SMBiosStruct;
 use serde::{ser::SerializeSeq, ser::SerializeStruct, Serialize, Serializer};
 use std::fmt;
@@ -30,7 +30,7 @@ impl<'a> SMBiosStruct<'a> for SMBiosGroupAssociations<'a> {
 
 impl<'a> SMBiosGroupAssociations<'a> {
     /// A string describing the group
-    pub fn group_name(&self) -> Result<String, SMBiosStringError> {
+    pub fn group_name(&self) -> SMBiosString {
         self.parts.get_field_string(0x4)
     }
 
@@ -246,7 +246,7 @@ mod tests {
         println!("{:?}", test_struct);
 
         assert_eq!(
-            test_struct.group_name().unwrap(),
+            test_struct.group_name().to_string(),
             "Firmware Version Info".to_string()
         );
         let mut iterator = test_struct.item_iterator().into_iter();

--- a/src/structs/types/management_device.rs
+++ b/src/structs/types/management_device.rs
@@ -1,4 +1,4 @@
-use crate::core::{SMBiosStringError, UndefinedStruct};
+use crate::core::{strings::*, UndefinedStruct};
 use crate::SMBiosStruct;
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use std::fmt;
@@ -29,7 +29,7 @@ impl<'a> SMBiosStruct<'a> for SMBiosManagementDevice<'a> {
 
 impl<'a> SMBiosManagementDevice<'a> {
     /// Additional descriptive information about the device or its location
-    pub fn description(&self) -> Result<String, SMBiosStringError> {
+    pub fn description(&self) -> SMBiosString {
         self.parts.get_field_string(0x04)
     }
 
@@ -286,7 +286,7 @@ mod tests {
         let parts = UndefinedStruct::new(&struct_type34);
         let test_struct = SMBiosManagementDevice::new(&parts);
 
-        assert_eq!(test_struct.description().unwrap(), "LM78-1".to_string());
+        assert_eq!(test_struct.description().to_string(), "LM78-1".to_string());
         assert_eq!(
             *test_struct.device_type().unwrap(),
             ManagementDeviceType::NationalSemiconductorLM78

--- a/src/structs/types/management_device.rs
+++ b/src/structs/types/management_device.rs
@@ -1,4 +1,5 @@
-use crate::{SMBiosStruct, UndefinedStruct};
+use crate::core::{SMBiosStringError, UndefinedStruct};
+use crate::SMBiosStruct;
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use std::fmt;
 use std::ops::Deref;
@@ -28,7 +29,7 @@ impl<'a> SMBiosStruct<'a> for SMBiosManagementDevice<'a> {
 
 impl<'a> SMBiosManagementDevice<'a> {
     /// Additional descriptive information about the device or its location
-    pub fn description(&self) -> Option<String> {
+    pub fn description(&self) -> Result<String, SMBiosStringError> {
         self.parts.get_field_string(0x04)
     }
 
@@ -285,7 +286,7 @@ mod tests {
         let parts = UndefinedStruct::new(&struct_type34);
         let test_struct = SMBiosManagementDevice::new(&parts);
 
-        assert_eq!(test_struct.description(), Some("LM78-1".to_string()));
+        assert_eq!(test_struct.description().unwrap(), "LM78-1".to_string());
         assert_eq!(
             *test_struct.device_type().unwrap(),
             ManagementDeviceType::NationalSemiconductorLM78

--- a/src/structs/types/management_device_component.rs
+++ b/src/structs/types/management_device_component.rs
@@ -1,4 +1,4 @@
-use crate::core::{Handle, SMBiosStringError, UndefinedStruct};
+use crate::core::{strings::*, Handle, UndefinedStruct};
 use crate::SMBiosStruct;
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use std::fmt;
@@ -29,7 +29,7 @@ impl<'a> SMBiosStruct<'a> for SMBiosManagementDeviceComponent<'a> {
 
 impl<'a> SMBiosManagementDeviceComponent<'a> {
     /// Number of the string that contains additional descriptive information about the component
-    pub fn description(&self) -> Result<String, SMBiosStringError> {
+    pub fn description(&self) -> SMBiosString {
         self.parts.get_field_string(0x04)
     }
 
@@ -94,7 +94,7 @@ mod tests {
         let test_struct = SMBiosManagementDeviceComponent::new(&parts);
 
         assert_eq!(
-            test_struct.description().unwrap(),
+            test_struct.description().to_string(),
             "Default string".to_string()
         );
         assert_eq!(*test_struct.management_device_handle().unwrap(), 38);

--- a/src/structs/types/management_device_component.rs
+++ b/src/structs/types/management_device_component.rs
@@ -1,4 +1,4 @@
-use crate::core::{Handle, UndefinedStruct};
+use crate::core::{Handle, SMBiosStringError, UndefinedStruct};
 use crate::SMBiosStruct;
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use std::fmt;
@@ -29,7 +29,7 @@ impl<'a> SMBiosStruct<'a> for SMBiosManagementDeviceComponent<'a> {
 
 impl<'a> SMBiosManagementDeviceComponent<'a> {
     /// Number of the string that contains additional descriptive information about the component
-    pub fn description(&self) -> Option<String> {
+    pub fn description(&self) -> Result<String, SMBiosStringError> {
         self.parts.get_field_string(0x04)
     }
 
@@ -94,8 +94,8 @@ mod tests {
         let test_struct = SMBiosManagementDeviceComponent::new(&parts);
 
         assert_eq!(
-            test_struct.description(),
-            Some("Default string".to_string())
+            test_struct.description().unwrap(),
+            "Default string".to_string()
         );
         assert_eq!(*test_struct.management_device_handle().unwrap(), 38);
         assert_eq!(*test_struct.component_handle().unwrap(), 39);

--- a/src/structs/types/memory_device.rs
+++ b/src/structs/types/memory_device.rs
@@ -1,4 +1,4 @@
-use crate::core::{Handle, SMBiosStringError, UndefinedStruct};
+use crate::core::{strings::*, Handle, UndefinedStruct};
 use crate::SMBiosStruct;
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use std::fmt;
@@ -95,13 +95,13 @@ impl<'a> SMBiosMemoryDevice<'a> {
     /// Identifies the physically-labeled socket or board position where
     /// the memory device is located
     /// EXAMPLE: “SIMM 3”
-    pub fn device_locator(&self) -> Result<String, SMBiosStringError> {
+    pub fn device_locator(&self) -> SMBiosString {
         self.parts.get_field_string(0x10)
     }
 
     /// Identifies the physically labeled bank where the memory device is located
     /// EXAMPLE: “Bank 0” or “A”
-    pub fn bank_locator(&self) -> Result<String, SMBiosStringError> {
+    pub fn bank_locator(&self) -> SMBiosString {
         self.parts.get_field_string(0x11)
     }
 
@@ -128,26 +128,26 @@ impl<'a> SMBiosMemoryDevice<'a> {
     }
 
     /// The manufacturer of this memory device
-    pub fn manufacturer(&self) -> Result<String, SMBiosStringError> {
+    pub fn manufacturer(&self) -> SMBiosString {
         self.parts.get_field_string(0x17)
     }
 
     /// The serial number of this memory device.
     /// This value is set by the manufacturer and normally
     /// is not changeable.
-    pub fn serial_number(&self) -> Result<String, SMBiosStringError> {
+    pub fn serial_number(&self) -> SMBiosString {
         self.parts.get_field_string(0x18)
     }
 
     /// The asset tag of this memory device
-    pub fn asset_tag(&self) -> Result<String, SMBiosStringError> {
+    pub fn asset_tag(&self) -> SMBiosString {
         self.parts.get_field_string(0x19)
     }
 
     /// The part number of this memory device.
     /// This value is set by the manufacturer and normally
     /// is not changeable.
-    pub fn part_number(&self) -> Result<String, SMBiosStringError> {
+    pub fn part_number(&self) -> SMBiosString {
         self.parts.get_field_string(0x1A)
     }
 
@@ -214,7 +214,7 @@ impl<'a> SMBiosMemoryDevice<'a> {
     }
 
     /// The firmware version of this memory device.
-    pub fn firmware_version(&self) -> Result<String, SMBiosStringError> {
+    pub fn firmware_version(&self) -> SMBiosString {
         self.parts.get_field_string(0x2B)
     }
 
@@ -1204,10 +1204,10 @@ mod tests {
         assert_eq!(*test_struct.form_factor().unwrap(), MemoryFormFactor::Dimm);
         assert_eq!(test_struct.device_set(), Some(0));
         assert_eq!(
-            test_struct.device_locator().unwrap(),
+            test_struct.device_locator().to_string(),
             "CPU1_DIMM_1".to_string()
         );
-        assert_eq!(test_struct.bank_locator().unwrap(), "NODE 1".to_string());
+        assert_eq!(test_struct.bank_locator().to_string(), "NODE 1".to_string());
         assert_eq!(
             test_struct.memory_type(),
             Some(MemoryDeviceTypeData::from(26))
@@ -1221,11 +1221,14 @@ mod tests {
             MemorySpeed::Unknown => panic!("expected speed"),
             MemorySpeed::SeeExtendedSpeed => panic!("expected speed"),
         }
-        assert_eq!(test_struct.manufacturer().unwrap(), "Hynix".to_string());
-        assert_eq!(test_struct.serial_number().unwrap(), "72091003".to_string());
-        assert_eq!(test_struct.asset_tag().unwrap(), " ".to_string());
+        assert_eq!(test_struct.manufacturer().to_string(), "Hynix".to_string());
         assert_eq!(
-            test_struct.part_number().unwrap(),
+            test_struct.serial_number().to_string(),
+            "72091003".to_string()
+        );
+        assert_eq!(test_struct.asset_tag().to_string(), " ".to_string());
+        assert_eq!(
+            test_struct.part_number().to_string(),
             "HMA81GR7AFR8N-VK    ".to_string()
         );
         assert_eq!(test_struct.attributes(), Some(1));
@@ -1281,7 +1284,7 @@ mod tests {
             .memory_operating_mode_capability()
             .unwrap()
             .block_accessible_persistent_memory());
-        assert_eq!(test_struct.firmware_version().unwrap(), "8".to_string());
+        assert_eq!(test_struct.firmware_version().to_string(), "8".to_string());
         assert_eq!(test_struct.module_manufacturer_id(), Some(0));
         assert_eq!(test_struct.module_product_id(), Some(0));
         assert_eq!(

--- a/src/structs/types/memory_module_information.rs
+++ b/src/structs/types/memory_module_information.rs
@@ -1,4 +1,5 @@
-use crate::{MemoryTypes, SMBiosStruct, UndefinedStruct};
+use crate::core::{SMBiosStringError, UndefinedStruct};
+use crate::{MemoryTypes, SMBiosStruct};
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use std::fmt;
 
@@ -29,7 +30,7 @@ impl<'a> SMBiosMemoryModuleInformation<'a> {
     /// Socket reference designation
     ///
     /// EXAMPLE: ‘J202’,0
-    pub fn socket_designation(&self) -> Option<String> {
+    pub fn socket_designation(&self) -> Result<String, SMBiosStringError> {
         self.parts.get_field_string(0x04)
     }
 
@@ -131,7 +132,7 @@ mod tests {
         let parts = UndefinedStruct::new(&struct_type6);
         let test_struct = SMBiosMemoryModuleInformation::new(&parts);
 
-        assert_eq!(test_struct.socket_designation(), Some("A1".to_string()));
+        assert_eq!(test_struct.socket_designation().unwrap(), "A1".to_string());
         assert_eq!(test_struct.bank_connections(), Some(0x01));
         assert_eq!(test_struct.current_speed(), Some(0b00000010));
         let memory_types = test_struct.current_memory_type().unwrap();

--- a/src/structs/types/memory_module_information.rs
+++ b/src/structs/types/memory_module_information.rs
@@ -1,4 +1,4 @@
-use crate::core::{SMBiosStringError, UndefinedStruct};
+use crate::core::{strings::*, UndefinedStruct};
 use crate::{MemoryTypes, SMBiosStruct};
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use std::fmt;
@@ -30,7 +30,7 @@ impl<'a> SMBiosMemoryModuleInformation<'a> {
     /// Socket reference designation
     ///
     /// EXAMPLE: ‘J202’,0
-    pub fn socket_designation(&self) -> Result<String, SMBiosStringError> {
+    pub fn socket_designation(&self) -> SMBiosString {
         self.parts.get_field_string(0x04)
     }
 
@@ -132,7 +132,10 @@ mod tests {
         let parts = UndefinedStruct::new(&struct_type6);
         let test_struct = SMBiosMemoryModuleInformation::new(&parts);
 
-        assert_eq!(test_struct.socket_designation().unwrap(), "A1".to_string());
+        assert_eq!(
+            test_struct.socket_designation().to_string(),
+            "A1".to_string()
+        );
         assert_eq!(test_struct.bank_connections(), Some(0x01));
         assert_eq!(test_struct.current_speed(), Some(0b00000010));
         let memory_types = test_struct.current_memory_type().unwrap();

--- a/src/structs/types/mod.rs
+++ b/src/structs/types/mod.rs
@@ -149,3 +149,6 @@ pub use voltage_probe::*;
 
 mod firmware_inventory_information;
 pub use firmware_inventory_information::*;
+
+mod string_property;
+pub use string_property::*;

--- a/src/structs/types/mod.rs
+++ b/src/structs/types/mod.rs
@@ -146,3 +146,6 @@ pub use tpm_device::*;
 
 mod voltage_probe;
 pub use voltage_probe::*;
+
+mod firmware_inventory_information;
+pub use firmware_inventory_information::*;

--- a/src/structs/types/oem_strings.rs
+++ b/src/structs/types/oem_strings.rs
@@ -86,16 +86,16 @@ mod tests {
 
         let mut iter = test_struct.oem_strings().into_iter();
         assert_eq!(
-            iter.next().unwrap().unwrap(),
-            "ABS 70/71 60 61 62 63;".to_string()
+            iter.next().unwrap().ok(),
+            Some("ABS 70/71 60 61 62 63;".to_string())
         );
         assert_eq!(
-            iter.next().unwrap().unwrap(),
-            "FBYTE#2U3E3X476J6S6b7B7H7M7Q7T7W7a7j7ma3apaqaub7.Q3;".to_string()
+            iter.next().unwrap().ok(),
+            Some("FBYTE#2U3E3X476J6S6b7B7H7M7Q7T7W7a7j7ma3apaqaub7.Q3;".to_string())
         );
         assert_eq!(
-            iter.next().unwrap().unwrap(),
-            "BUILDID#13WWCDC8601#SABA#DABA;".to_string()
+            iter.next().unwrap().ok(),
+            Some("BUILDID#13WWCDC8601#SABA#DABA;".to_string())
         );
     }
 }

--- a/src/structs/types/oem_strings.rs
+++ b/src/structs/types/oem_strings.rs
@@ -1,4 +1,4 @@
-use crate::{SMBiosStruct, Strings, UndefinedStruct};
+use crate::{SMBiosStringSet, SMBiosStruct, UndefinedStruct};
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use std::fmt;
 
@@ -33,7 +33,7 @@ impl<'a> SMBiosOemStrings<'a> {
     }
 
     /// Iterable collection of OEM strings
-    pub fn oem_strings(&self) -> &Strings {
+    pub fn oem_strings(&self) -> &SMBiosStringSet {
         &self.parts.strings
     }
 }

--- a/src/structs/types/oem_strings.rs
+++ b/src/structs/types/oem_strings.rs
@@ -85,14 +85,17 @@ mod tests {
         assert_eq!(test_struct.count(), Some(0x03));
 
         let mut iter = test_struct.oem_strings().into_iter();
-        assert_eq!(iter.next(), Some("ABS 70/71 60 61 62 63;".to_string()));
         assert_eq!(
-            iter.next(),
-            Some("FBYTE#2U3E3X476J6S6b7B7H7M7Q7T7W7a7j7ma3apaqaub7.Q3;".to_string())
+            iter.next().unwrap().unwrap(),
+            "ABS 70/71 60 61 62 63;".to_string()
         );
         assert_eq!(
-            iter.next(),
-            Some("BUILDID#13WWCDC8601#SABA#DABA;".to_string())
+            iter.next().unwrap().unwrap(),
+            "FBYTE#2U3E3X476J6S6b7B7H7M7Q7T7W7a7j7ma3apaqaub7.Q3;".to_string()
+        );
+        assert_eq!(
+            iter.next().unwrap().unwrap(),
+            "BUILDID#13WWCDC8601#SABA#DABA;".to_string()
         );
     }
 }

--- a/src/structs/types/on_board_device_information.rs
+++ b/src/structs/types/on_board_device_information.rs
@@ -13,8 +13,8 @@ use std::fmt;
 /// both types to allow existing SMBIOS browsers to properly display the system’s onboard devices information.
 ///
 /// Compliant with:
-/// DMTF SMBIOS Reference Specification 3.4.0 (DSP0134)
-/// Document Date: 2020-07-17
+/// DMTF SMBIOS Reference Specification 3.5.0 (DSP0134)
+/// Document Date: 2021-09-15
 pub struct SMBiosOnBoardDeviceInformation<'a> {
     parts: &'a UndefinedStruct,
 }
@@ -151,6 +151,12 @@ impl OnBoardDeviceType {
             0x08 => TypeOfDevice::PataController,
             0x09 => TypeOfDevice::SataController,
             0x0A => TypeOfDevice::SasController,
+            0x0B => TypeOfDevice::WirelessLan,
+            0x0C => TypeOfDevice::Bluetooth,
+            0x0D => TypeOfDevice::Wwan,
+            0x0E => TypeOfDevice::Emmc,
+            0x0F => TypeOfDevice::NvmeController,
+            0x10 => TypeOfDevice::UfsController,
             _ => TypeOfDevice::None,
         }
     }
@@ -217,6 +223,18 @@ pub enum TypeOfDevice {
     SataController,
     /// SAS Controller
     SasController,
+    /// Wireless LAN
+    WirelessLan,
+    /// Bluetooth
+    Bluetooth,
+    /// WWAN
+    Wwan,
+    /// eMMC (embedded Milti-Media Controller)
+    Emmc,
+    /// NVMe Controller
+    NvmeController,
+    /// UFS Controller
+    UfsController,
     /// A value unknown to this standard, check the raw value
     None,
 }

--- a/src/structs/types/on_board_device_information.rs
+++ b/src/structs/types/on_board_device_information.rs
@@ -1,4 +1,5 @@
-use crate::{Header, SMBiosStruct, UndefinedStruct};
+use crate::core::{Header, SMBiosStringError, UndefinedStruct};
+use crate::SMBiosStruct;
 use serde::{ser::SerializeSeq, ser::SerializeStruct, Serialize, Serializer};
 use std::fmt;
 
@@ -102,7 +103,7 @@ impl<'a> OnBoardDevice<'a> {
     }
 
     /// Device description
-    pub fn description(&self) -> Option<String> {
+    pub fn description(&self) -> Result<String, SMBiosStringError> {
         self.onboard_device_information
             .parts()
             .get_field_string(self.entry_offset + 1)
@@ -361,8 +362,8 @@ mod tests {
         let item = iterator.next().unwrap();
 
         assert_eq!(
-            item.description(),
-            Some("   To Be Filled By O.E.M.".to_string())
+            item.description().unwrap(),
+            "   To Be Filled By O.E.M.".to_string()
         );
 
         let device_type = item.device_type().unwrap();

--- a/src/structs/types/on_board_device_information.rs
+++ b/src/structs/types/on_board_device_information.rs
@@ -1,4 +1,4 @@
-use crate::core::{Header, SMBiosStringError, UndefinedStruct};
+use crate::core::{strings::*, Header, UndefinedStruct};
 use crate::SMBiosStruct;
 use serde::{ser::SerializeSeq, ser::SerializeStruct, Serialize, Serializer};
 use std::fmt;
@@ -103,7 +103,7 @@ impl<'a> OnBoardDevice<'a> {
     }
 
     /// Device description
-    pub fn description(&self) -> Result<String, SMBiosStringError> {
+    pub fn description(&self) -> SMBiosString {
         self.onboard_device_information
             .parts()
             .get_field_string(self.entry_offset + 1)
@@ -362,7 +362,7 @@ mod tests {
         let item = iterator.next().unwrap();
 
         assert_eq!(
-            item.description().unwrap(),
+            item.description().to_string(),
             "   To Be Filled By O.E.M.".to_string()
         );
 

--- a/src/structs/types/onboard_devices_extended_information.rs
+++ b/src/structs/types/onboard_devices_extended_information.rs
@@ -11,13 +11,16 @@ use std::fmt;
 /// In general, an entry in this table implies that the BIOS has some level of control over the enablement of
 /// the associated device for use by the system.
 ///
+/// To describe multi-function devices, use one type 41 structure per function, and one type 14 (Group
+/// Association) structure referencing all the function handles.
+///
 /// NOTE: This structure replaces Onboard Device Information (Type 10) starting with version 2.6 of this specification.
 /// BIOS providers can choose to implement both types to allow existing SMBIOS browsers to properly display
 /// the system’s onboard devices information.
-///  
+///
 /// Compliant with:
-/// DMTF SMBIOS Reference Specification 3.4.0 (DSP0134)
-/// Document Date: 2020-07-17
+/// DMTF SMBIOS Reference Specification 3.5.0 (DSP0134)
+/// Document Date: 2021-09-15
 pub struct SMBiosOnboardDevicesExtendedInformation<'a> {
     parts: &'a UndefinedStruct,
 }

--- a/src/structs/types/onboard_devices_extended_information.rs
+++ b/src/structs/types/onboard_devices_extended_information.rs
@@ -1,5 +1,6 @@
 use super::system_slot::{BusNumber, DeviceFunctionNumber, SegmentGroupNumber};
-use crate::{OnBoardDeviceType, SMBiosStruct, UndefinedStruct};
+use crate::core::{SMBiosStringError, UndefinedStruct};
+use crate::{OnBoardDeviceType, SMBiosStruct};
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use std::fmt;
 
@@ -39,7 +40,7 @@ impl<'a> SMBiosStruct<'a> for SMBiosOnboardDevicesExtendedInformation<'a> {
 
 impl<'a> SMBiosOnboardDevicesExtendedInformation<'a> {
     /// The onboard device reference designation
-    pub fn reference_designation(&self) -> Option<String> {
+    pub fn reference_designation(&self) -> Result<String, SMBiosStringError> {
         self.parts.get_field_string(0x4)
     }
 
@@ -127,8 +128,8 @@ mod tests {
         let test_struct = SMBiosOnboardDevicesExtendedInformation::new(&parts);
 
         assert_eq!(
-            test_struct.reference_designation(),
-            Some("i219".to_string())
+            test_struct.reference_designation().unwrap(),
+            "i219".to_string()
         );
         let device_type = test_struct.device_type().unwrap();
         assert_eq!(device_type.type_of_device(), TypeOfDevice::Ethernet);

--- a/src/structs/types/onboard_devices_extended_information.rs
+++ b/src/structs/types/onboard_devices_extended_information.rs
@@ -1,5 +1,5 @@
 use super::system_slot::{BusNumber, DeviceFunctionNumber, SegmentGroupNumber};
-use crate::core::{SMBiosStringError, UndefinedStruct};
+use crate::core::{strings::*, UndefinedStruct};
 use crate::{OnBoardDeviceType, SMBiosStruct};
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use std::fmt;
@@ -40,7 +40,7 @@ impl<'a> SMBiosStruct<'a> for SMBiosOnboardDevicesExtendedInformation<'a> {
 
 impl<'a> SMBiosOnboardDevicesExtendedInformation<'a> {
     /// The onboard device reference designation
-    pub fn reference_designation(&self) -> Result<String, SMBiosStringError> {
+    pub fn reference_designation(&self) -> SMBiosString {
         self.parts.get_field_string(0x4)
     }
 
@@ -128,7 +128,7 @@ mod tests {
         let test_struct = SMBiosOnboardDevicesExtendedInformation::new(&parts);
 
         assert_eq!(
-            test_struct.reference_designation().unwrap(),
+            test_struct.reference_designation().to_string(),
             "i219".to_string()
         );
         let device_type = test_struct.device_type().unwrap();

--- a/src/structs/types/out_of_band_remote_access.rs
+++ b/src/structs/types/out_of_band_remote_access.rs
@@ -1,5 +1,5 @@
 use crate::SMBiosStruct;
-use crate::{SMBiosStringError, UndefinedStruct};
+use crate::{strings::*, UndefinedStruct};
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use std::{fmt, ops::Deref};
 
@@ -32,7 +32,7 @@ impl<'a> SMBiosStruct<'a> for SMBiosOutOfBandRemoteAccess<'a> {
 
 impl<'a> SMBiosOutOfBandRemoteAccess<'a> {
     ///  The manufacturer of the out-of-band access facility
-    pub fn manufacturer_name(&self) -> Result<String, SMBiosStringError> {
+    pub fn manufacturer_name(&self) -> SMBiosString {
         self.parts.get_field_string(0x04)
     }
 
@@ -158,7 +158,10 @@ mod tests {
         let parts = UndefinedStruct::new(&struct_type41);
         let test_struct = SMBiosOutOfBandRemoteAccess::new(&parts);
 
-        assert_eq!(test_struct.manufacturer_name().unwrap(), "ijkl".to_string());
+        assert_eq!(
+            test_struct.manufacturer_name().to_string(),
+            "ijkl".to_string()
+        );
 
         let connections = test_struct.connections().unwrap();
         assert!(connections.inbound_connection_enabled());

--- a/src/structs/types/out_of_band_remote_access.rs
+++ b/src/structs/types/out_of_band_remote_access.rs
@@ -1,4 +1,5 @@
-use crate::{SMBiosStruct, UndefinedStruct};
+use crate::SMBiosStruct;
+use crate::{SMBiosStringError, UndefinedStruct};
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use std::{fmt, ops::Deref};
 
@@ -31,7 +32,7 @@ impl<'a> SMBiosStruct<'a> for SMBiosOutOfBandRemoteAccess<'a> {
 
 impl<'a> SMBiosOutOfBandRemoteAccess<'a> {
     ///  The manufacturer of the out-of-band access facility
-    pub fn manufacturer_name(&self) -> Option<String> {
+    pub fn manufacturer_name(&self) -> Result<String, SMBiosStringError> {
         self.parts.get_field_string(0x04)
     }
 
@@ -157,7 +158,7 @@ mod tests {
         let parts = UndefinedStruct::new(&struct_type41);
         let test_struct = SMBiosOutOfBandRemoteAccess::new(&parts);
 
-        assert_eq!(test_struct.manufacturer_name(), Some("ijkl".to_string()));
+        assert_eq!(test_struct.manufacturer_name().unwrap(), "ijkl".to_string());
 
         let connections = test_struct.connections().unwrap();
         assert!(connections.inbound_connection_enabled());

--- a/src/structs/types/port_connector_information.rs
+++ b/src/structs/types/port_connector_information.rs
@@ -1,4 +1,4 @@
-use crate::core::{SMBiosStringError, UndefinedStruct};
+use crate::core::{strings::*, UndefinedStruct};
 use crate::SMBiosStruct;
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use std::{fmt, ops::Deref};
@@ -33,7 +33,7 @@ impl<'a> SMBiosPortConnectorInformation<'a> {
     /// internal to the system enclosure
     ///
     /// EXAMPLE: "J101"
-    pub fn internal_reference_designator(&self) -> Result<String, SMBiosStringError> {
+    pub fn internal_reference_designator(&self) -> SMBiosString {
         self.parts.get_field_string(0x04)
     }
 
@@ -48,7 +48,7 @@ impl<'a> SMBiosPortConnectorInformation<'a> {
     /// external to the system enclosure
     ///
     /// EXAMPLE: "COM A"
-    pub fn external_reference_designator(&self) -> Result<String, SMBiosStringError> {
+    pub fn external_reference_designator(&self) -> SMBiosString {
         self.parts.get_field_string(0x06)
     }
 
@@ -504,7 +504,7 @@ mod tests {
         let test_struct = SMBiosPortConnectorInformation::new(&parts);
 
         assert_eq!(
-            test_struct.internal_reference_designator().unwrap(),
+            test_struct.internal_reference_designator().to_string(),
             "J1A1".to_string()
         );
         assert_eq!(
@@ -512,7 +512,7 @@ mod tests {
             PortInformationConnectorType::NoConnector
         );
         assert_eq!(
-            test_struct.external_reference_designator().unwrap(),
+            test_struct.external_reference_designator().to_string(),
             "PS2Mouse".to_string()
         );
         assert_eq!(

--- a/src/structs/types/port_connector_information.rs
+++ b/src/structs/types/port_connector_information.rs
@@ -1,4 +1,5 @@
-use crate::{SMBiosStruct, UndefinedStruct};
+use crate::core::{SMBiosStringError, UndefinedStruct};
+use crate::SMBiosStruct;
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use std::{fmt, ops::Deref};
 
@@ -32,7 +33,7 @@ impl<'a> SMBiosPortConnectorInformation<'a> {
     /// internal to the system enclosure
     ///
     /// EXAMPLE: "J101"
-    pub fn internal_reference_designator(&self) -> Option<String> {
+    pub fn internal_reference_designator(&self) -> Result<String, SMBiosStringError> {
         self.parts.get_field_string(0x04)
     }
 
@@ -47,7 +48,7 @@ impl<'a> SMBiosPortConnectorInformation<'a> {
     /// external to the system enclosure
     ///
     /// EXAMPLE: "COM A"
-    pub fn external_reference_designator(&self) -> Option<String> {
+    pub fn external_reference_designator(&self) -> Result<String, SMBiosStringError> {
         self.parts.get_field_string(0x06)
     }
 
@@ -503,16 +504,16 @@ mod tests {
         let test_struct = SMBiosPortConnectorInformation::new(&parts);
 
         assert_eq!(
-            test_struct.internal_reference_designator(),
-            Some("J1A1".to_string())
+            test_struct.internal_reference_designator().unwrap(),
+            "J1A1".to_string()
         );
         assert_eq!(
             *test_struct.internal_connector_type().unwrap(),
             PortInformationConnectorType::NoConnector
         );
         assert_eq!(
-            test_struct.external_reference_designator(),
-            Some("PS2Mouse".to_string())
+            test_struct.external_reference_designator().unwrap(),
+            "PS2Mouse".to_string()
         );
         assert_eq!(
             *test_struct.external_connector_type().unwrap(),

--- a/src/structs/types/portable_battery.rs
+++ b/src/structs/types/portable_battery.rs
@@ -1,4 +1,4 @@
-use crate::core::{SMBiosStringError, UndefinedStruct};
+use crate::core::{strings::*, UndefinedStruct};
 use crate::SMBiosStruct;
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use std::fmt;
@@ -30,12 +30,12 @@ impl<'a> SMBiosStruct<'a> for SMBiosPortableBattery<'a> {
 
 impl<'a> SMBiosPortableBattery<'a> {
     /// Identifies the location of the battery
-    pub fn location(&self) -> Result<String, SMBiosStringError> {
+    pub fn location(&self) -> SMBiosString {
         self.parts.get_field_string(0x04)
     }
 
     /// Names the company that manufactured the battery
-    pub fn manufacturer(&self) -> Result<String, SMBiosStringError> {
+    pub fn manufacturer(&self) -> SMBiosString {
         self.parts.get_field_string(0x05)
     }
 
@@ -45,7 +45,7 @@ impl<'a> SMBiosPortableBattery<'a> {
     /// Battery set this field to 0 (no string) to indicate
     /// that the SBDS Manufacture Date field contains
     /// the information.
-    pub fn manufacture_date(&self) -> Result<String, SMBiosStringError> {
+    pub fn manufacture_date(&self) -> SMBiosString {
         self.parts.get_field_string(0x06)
     }
 
@@ -55,14 +55,14 @@ impl<'a> SMBiosPortableBattery<'a> {
     /// Battery set this field to 0 (no string) to indicate
     /// that the SBDS Serial Number field contains the
     /// information.
-    pub fn serial_number(&self) -> Result<String, SMBiosStringError> {
+    pub fn serial_number(&self) -> SMBiosString {
         self.parts.get_field_string(0x07)
     }
 
     /// Names the battery device
     ///
     /// EXAMPLE: "DR-36"
-    pub fn device_name(&self) -> Result<String, SMBiosStringError> {
+    pub fn device_name(&self) -> SMBiosString {
         self.parts.get_field_string(0x08)
     }
 
@@ -105,7 +105,7 @@ impl<'a> SMBiosPortableBattery<'a> {
     ///
     /// If the battery does not support the function, no
     /// string is supplied.
-    pub fn sbds_version_number(&self) -> Result<String, SMBiosStringError> {
+    pub fn sbds_version_number(&self) -> SMBiosString {
         self.parts.get_field_string(0x0E)
     }
 
@@ -142,7 +142,7 @@ impl<'a> SMBiosPortableBattery<'a> {
     /// chemistry (for example, “PbAc”)
     /// The Device Chemistry field must be set to 02h
     /// (Unknown) for this field to be valid.
-    pub fn sbds_device_chemistry(&self) -> Result<String, SMBiosStringError> {
+    pub fn sbds_device_chemistry(&self) -> SMBiosString {
         self.parts.get_field_string(0x14)
     }
 
@@ -370,11 +370,11 @@ mod tests {
         let parts = UndefinedStruct::new(&struct_type22);
         let test_struct = SMBiosPortableBattery::new(&parts);
 
-        assert_eq!(test_struct.location().unwrap(), "Rear".to_string());
-        assert_eq!(test_struct.manufacturer().unwrap(), "SMP".to_string());
-        assert_eq!(test_struct.manufacture_date().unwrap(), "".to_string());
-        assert_eq!(test_struct.serial_number().unwrap(), "".to_string());
-        assert_eq!(test_struct.device_name().unwrap(), "45N1071".to_string());
+        assert_eq!(test_struct.location().to_string(), "Rear".to_string());
+        assert_eq!(test_struct.manufacturer().to_string(), "SMP".to_string());
+        assert_eq!(test_struct.manufacture_date().to_string(), "".to_string());
+        assert_eq!(test_struct.serial_number().to_string(), "".to_string());
+        assert_eq!(test_struct.device_name().to_string(), "45N1071".to_string());
         assert_eq!(
             *test_struct.device_chemistry().unwrap(),
             PortableBatteryDeviceChemistry::Unknown
@@ -388,14 +388,14 @@ mod tests {
             PortableBatteryDesignVoltage::Unknown => panic!("expected a value in mWH"),
         }
         assert_eq!(
-            test_struct.sbds_version_number().unwrap(),
+            test_struct.sbds_version_number().to_string(),
             "03.01".to_string()
         );
         assert_eq!(test_struct.maximum_error_in_battery_data(), Some(255));
         assert_eq!(test_struct.sbds_serial_number(), Some(711));
         assert_eq!(test_struct.sbds_manufacture_date(), Some(17018));
         assert_eq!(
-            test_struct.sbds_device_chemistry().unwrap(),
+            test_struct.sbds_device_chemistry().to_string(),
             "LiP".to_string()
         );
         assert_eq!(test_struct.design_capacity_multiplier(), Some(10));

--- a/src/structs/types/processor_information.rs
+++ b/src/structs/types/processor_information.rs
@@ -1401,6 +1401,8 @@ pub enum ProcessorUpgrade {
     SocketLGA4189,
     /// Socket LGA1200
     SocketLGA1200,
+    /// Socket LGA4677
+    SocketLGA4677,
     /// A value unknown to this standard, check the raw value
     None,
 }
@@ -1471,6 +1473,7 @@ impl From<u8> for ProcessorUpgradeData {
                 0x3C => ProcessorUpgrade::SocketBGA1528,
                 0x3D => ProcessorUpgrade::SocketLGA4189,
                 0x3E => ProcessorUpgrade::SocketLGA1200,
+                0x3F => ProcessorUpgrade::SocketLGA4677,
                 _ => ProcessorUpgrade::None,
             },
             raw,

--- a/src/structs/types/processor_information.rs
+++ b/src/structs/types/processor_information.rs
@@ -1,4 +1,4 @@
-use crate::core::{Handle, UndefinedStruct};
+use crate::core::{Handle, SMBiosStringError, UndefinedStruct};
 use crate::SMBiosStruct;
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use std::convert::TryInto;
@@ -40,7 +40,7 @@ impl<'a> SMBiosProcessorInformation<'a> {
     /// Socket reference designation
     ///
     /// EXAMPLE: "J202"
-    pub fn socket_designation(&self) -> Option<String> {
+    pub fn socket_designation(&self) -> Result<String, SMBiosStringError> {
         self.parts.get_field_string(0x04)
     }
 
@@ -59,7 +59,7 @@ impl<'a> SMBiosProcessorInformation<'a> {
     }
 
     /// Processor manufacturer
-    pub fn processor_manufacturer(&self) -> Option<String> {
+    pub fn processor_manufacturer(&self) -> Result<String, SMBiosStringError> {
         self.parts.get_field_string(0x07)
     }
 
@@ -76,7 +76,7 @@ impl<'a> SMBiosProcessorInformation<'a> {
     }
 
     /// Processor version
-    pub fn processor_version(&self) -> Option<String> {
+    pub fn processor_version(&self) -> Result<String, SMBiosStringError> {
         self.parts.get_field_string(0x10)
     }
 
@@ -179,12 +179,12 @@ impl<'a> SMBiosProcessorInformation<'a> {
     ///
     /// This value is set by the manufacturer and
     /// normally not changeable.
-    pub fn serial_number(&self) -> Option<String> {
+    pub fn serial_number(&self) -> Result<String, SMBiosStringError> {
         self.parts.get_field_string(0x20)
     }
 
     /// The asset tag of this processor
-    pub fn asset_tag(&self) -> Option<String> {
+    pub fn asset_tag(&self) -> Result<String, SMBiosStringError> {
         self.parts.get_field_string(0x21)
     }
 
@@ -192,7 +192,7 @@ impl<'a> SMBiosProcessorInformation<'a> {
     ///
     /// This value is set by the manufacturer and
     /// normally not changeable.
-    pub fn part_number(&self) -> Option<String> {
+    pub fn part_number(&self) -> Result<String, SMBiosStringError> {
         self.parts.get_field_string(0x22)
     }
 
@@ -1985,7 +1985,10 @@ mod tests {
         let parts = UndefinedStruct::new(&struct_type4);
         let test_struct = SMBiosProcessorInformation::new(&parts);
 
-        assert_eq!(test_struct.socket_designation(), Some("CPU0".to_string()));
+        assert_eq!(
+            test_struct.socket_designation().unwrap(),
+            "CPU0".to_string()
+        );
         assert_eq!(
             *test_struct.processor_type().unwrap(),
             ProcessorType::CentralProcessor
@@ -1995,16 +1998,16 @@ mod tests {
             ProcessorFamily::IntelXeonProcessor
         );
         assert_eq!(
-            test_struct.processor_manufacturer(),
-            Some("Intel(R) Corporation".to_string())
+            test_struct.processor_manufacturer().unwrap(),
+            "Intel(R) Corporation".to_string()
         );
         assert_eq!(
             test_struct.processor_id(),
             Some(&[0x54u8, 0x06, 0x05, 0x00, 0xFF, 0xFB, 0xEB, 0xBF])
         );
         assert_eq!(
-            test_struct.processor_version(),
-            Some("Intel(R) Xeon(R) W-2133 CPU @ 3.60GHz".to_string())
+            test_struct.processor_version().unwrap(),
+            "Intel(R) Xeon(R) W-2133 CPU @ 3.60GHz".to_string()
         );
         match test_struct.voltage().unwrap() {
             ProcessorVoltage::CurrentVolts(volts) => assert_eq!(volts, 1.6),
@@ -2032,9 +2035,9 @@ mod tests {
         assert_eq!(*test_struct.l1cache_handle().unwrap(), 83);
         assert_eq!(*test_struct.l2cache_handle().unwrap(), 84);
         assert_eq!(*test_struct.l3cache_handle().unwrap(), 85);
-        assert_eq!(test_struct.serial_number(), None);
-        assert_eq!(test_struct.asset_tag(), Some("UNKNOWN".to_string()));
-        assert_eq!(test_struct.part_number(), None);
+        assert_eq!(test_struct.serial_number().unwrap(), "".to_string());
+        assert_eq!(test_struct.asset_tag().unwrap(), "UNKNOWN".to_string());
+        assert_eq!(test_struct.part_number().unwrap(), "".to_string());
         match test_struct.core_count().unwrap() {
             CoreCount::Count(number) => assert_eq!(number, 6),
             CoreCount::Unknown => panic!("expected number"),

--- a/src/structs/types/processor_information.rs
+++ b/src/structs/types/processor_information.rs
@@ -18,8 +18,8 @@ use std::ops::Deref;
 /// determine the maximum possible configuration of the system.
 ///
 /// Compliant with:
-/// DMTF SMBIOS Reference Specification 3.4.0 (DSP0134)
-/// Document Date: 2020-07-17
+/// DMTF SMBIOS Reference Specification 3.5.0 (DSP0134)
+/// Document Date: 2021-09-15
 pub struct SMBiosProcessorInformation<'a> {
     parts: &'a UndefinedStruct,
 }

--- a/src/structs/types/processor_information.rs
+++ b/src/structs/types/processor_information.rs
@@ -1,4 +1,4 @@
-use crate::core::{Handle, SMBiosStringError, UndefinedStruct};
+use crate::core::{strings::*, Handle, UndefinedStruct};
 use crate::SMBiosStruct;
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use std::convert::TryInto;
@@ -40,7 +40,7 @@ impl<'a> SMBiosProcessorInformation<'a> {
     /// Socket reference designation
     ///
     /// EXAMPLE: "J202"
-    pub fn socket_designation(&self) -> Result<String, SMBiosStringError> {
+    pub fn socket_designation(&self) -> SMBiosString {
         self.parts.get_field_string(0x04)
     }
 
@@ -59,7 +59,7 @@ impl<'a> SMBiosProcessorInformation<'a> {
     }
 
     /// Processor manufacturer
-    pub fn processor_manufacturer(&self) -> Result<String, SMBiosStringError> {
+    pub fn processor_manufacturer(&self) -> SMBiosString {
         self.parts.get_field_string(0x07)
     }
 
@@ -76,7 +76,7 @@ impl<'a> SMBiosProcessorInformation<'a> {
     }
 
     /// Processor version
-    pub fn processor_version(&self) -> Result<String, SMBiosStringError> {
+    pub fn processor_version(&self) -> SMBiosString {
         self.parts.get_field_string(0x10)
     }
 
@@ -179,12 +179,12 @@ impl<'a> SMBiosProcessorInformation<'a> {
     ///
     /// This value is set by the manufacturer and
     /// normally not changeable.
-    pub fn serial_number(&self) -> Result<String, SMBiosStringError> {
+    pub fn serial_number(&self) -> SMBiosString {
         self.parts.get_field_string(0x20)
     }
 
     /// The asset tag of this processor
-    pub fn asset_tag(&self) -> Result<String, SMBiosStringError> {
+    pub fn asset_tag(&self) -> SMBiosString {
         self.parts.get_field_string(0x21)
     }
 
@@ -192,7 +192,7 @@ impl<'a> SMBiosProcessorInformation<'a> {
     ///
     /// This value is set by the manufacturer and
     /// normally not changeable.
-    pub fn part_number(&self) -> Result<String, SMBiosStringError> {
+    pub fn part_number(&self) -> SMBiosString {
         self.parts.get_field_string(0x22)
     }
 
@@ -1986,7 +1986,7 @@ mod tests {
         let test_struct = SMBiosProcessorInformation::new(&parts);
 
         assert_eq!(
-            test_struct.socket_designation().unwrap(),
+            test_struct.socket_designation().to_string(),
             "CPU0".to_string()
         );
         assert_eq!(
@@ -1998,7 +1998,7 @@ mod tests {
             ProcessorFamily::IntelXeonProcessor
         );
         assert_eq!(
-            test_struct.processor_manufacturer().unwrap(),
+            test_struct.processor_manufacturer().to_string(),
             "Intel(R) Corporation".to_string()
         );
         assert_eq!(
@@ -2006,7 +2006,7 @@ mod tests {
             Some(&[0x54u8, 0x06, 0x05, 0x00, 0xFF, 0xFB, 0xEB, 0xBF])
         );
         assert_eq!(
-            test_struct.processor_version().unwrap(),
+            test_struct.processor_version().to_string(),
             "Intel(R) Xeon(R) W-2133 CPU @ 3.60GHz".to_string()
         );
         match test_struct.voltage().unwrap() {
@@ -2035,9 +2035,9 @@ mod tests {
         assert_eq!(*test_struct.l1cache_handle().unwrap(), 83);
         assert_eq!(*test_struct.l2cache_handle().unwrap(), 84);
         assert_eq!(*test_struct.l3cache_handle().unwrap(), 85);
-        assert_eq!(test_struct.serial_number().unwrap(), "".to_string());
-        assert_eq!(test_struct.asset_tag().unwrap(), "UNKNOWN".to_string());
-        assert_eq!(test_struct.part_number().unwrap(), "".to_string());
+        assert_eq!(test_struct.serial_number().to_string(), "".to_string());
+        assert_eq!(test_struct.asset_tag().to_string(), "UNKNOWN".to_string());
+        assert_eq!(test_struct.part_number().to_string(), "".to_string());
         match test_struct.core_count().unwrap() {
             CoreCount::Count(number) => assert_eq!(number, 6),
             CoreCount::Unknown => panic!("expected number"),

--- a/src/structs/types/string_property.rs
+++ b/src/structs/types/string_property.rs
@@ -1,0 +1,193 @@
+use crate::core::Handle;
+use crate::{SMBiosStruct, UndefinedStruct};
+use serde::{ser::SerializeStruct, Serialize, Serializer};
+use std::fmt;
+use std::ops::Deref;
+
+/// # String Property (Type 46)
+///
+/// This structure defines a string property for another structure. This allows adding string properties that are
+/// common to several structures without having to modify the definitions of these structures. Multiple type 46
+/// structures can add string properties to the same parent structure.
+///
+/// NOTE: This structure type was added in version 3.5 of this specification.
+///
+/// Compliant with:
+/// DMTF SMBIOS Reference Specification 3.5.0 (DSP0134)
+/// Document Date: 2021-09-15
+pub struct SMBiosStringProperty<'a> {
+    parts: &'a UndefinedStruct,
+}
+
+impl<'a> SMBiosStruct<'a> for SMBiosStringProperty<'a> {
+    const STRUCT_TYPE: u8 = 46u8;
+
+    fn new(parts: &'a UndefinedStruct) -> Self {
+        Self { parts }
+    }
+
+    fn parts(&self) -> &'a UndefinedStruct {
+        self.parts
+    }
+}
+
+impl<'a> SMBiosStringProperty<'a> {
+    /// String Property Id
+    pub fn string_property_id(&self) -> Option<StringPropertyIdData> {
+        self.parts
+            .get_field_word(0x04)
+            .map(|raw| StringPropertyIdData::from(raw))
+    }
+
+    /// String Property Value
+    pub fn string_property_value(&self) -> Option<String> {
+        self.parts.get_field_string(0x06)
+    }
+
+    /// Parent Handle
+    ///
+    /// Handle corresponding to the structure this string property applies to
+    pub fn parent_handle(&self) -> Option<Handle> {
+        self.parts.get_field_handle(0x07)
+    }
+}
+
+impl fmt::Debug for SMBiosStringProperty<'_> {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.debug_struct(std::any::type_name::<SMBiosStringProperty<'_>>())
+            .field("header", &self.parts.header)
+            .field("string_property_id", &self.string_property_id())
+            .field("string_property_value", &self.string_property_value())
+            .field("parent_handle", &self.parent_handle())
+            .finish()
+    }
+}
+
+impl Serialize for SMBiosStringProperty<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut state = serializer.serialize_struct("SMBiosStringProperty", 3)?;
+        state.serialize_field("header", &self.parts.header)?;
+        state.serialize_field("string_property_id", &self.string_property_id())?;
+        state.serialize_field("string_property_value", &self.string_property_value())?;
+        state.serialize_field("parent_handle", &self.parent_handle())?;
+        state.end()
+    }
+}
+
+/// # String Property Id Data of [SMBiosStringProperty].
+pub struct StringPropertyIdData {
+    /// Raw value
+    ///
+    /// _raw_ is most useful when _value_ is None.
+    /// This is most likely to occur when the standard was updated but
+    /// this library code has not been updated to match the current
+    /// standard.
+    pub raw: u16,
+    /// The contained [StringPropertyId] value
+    pub value: StringPropertyId,
+}
+
+impl fmt::Debug for StringPropertyIdData {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.debug_struct(std::any::type_name::<StringPropertyIdData>())
+            .field("raw", &self.raw)
+            .field("value", &self.value)
+            .finish()
+    }
+}
+
+impl Serialize for StringPropertyIdData {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut state = serializer.serialize_struct("StringPropertyIdData", 2)?;
+        state.serialize_field("raw", &self.raw)?;
+        state.serialize_field("value", &self.value)?;
+        state.end()
+    }
+}
+
+impl fmt::Display for StringPropertyIdData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.value {
+            StringPropertyId::None => write!(f, "{}", &self.raw),
+            _ => write!(f, "{:?}", &self.value),
+        }
+    }
+}
+
+impl Deref for StringPropertyIdData {
+    type Target = StringPropertyId;
+
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
+impl From<u16> for StringPropertyIdData {
+    fn from(raw: u16) -> Self {
+        StringPropertyIdData {
+            value: match raw {
+                0x0001 => StringPropertyId::UefiDevicePath,
+                _ => match raw & 0b1000_0000_0000_0000 {
+                    // >= 32768 ?
+                    0b1000_0000_0000_0000 => match raw & 0b1100_0000_0000_0000 {
+                        // >= 49152 ?
+                        0b1100_0000_0000_0000 => StringPropertyId::OemSpecific, // 49152-65535
+                        _ => StringPropertyId::VendorSpecific,                  // 32768-49151
+                    },
+                    _ => StringPropertyId::None,
+                },
+            },
+            raw,
+        }
+    }
+}
+
+/// # String Property Id of [SMBiosStringProperty]
+#[derive(Serialize, Debug, PartialEq, Eq)]
+pub enum StringPropertyId {
+    /// UEFI Device Path
+    ///
+    /// String representation of a UEFI device path, as converted by
+    /// EFI_DEVICE_PATH_TO_TEXT_PROTOCOL. ConvertDevicePathToText() and then converted to UTF-8
+    UefiDevicePath,
+    /// Vendor Specific
+    VendorSpecific,
+    /// OEM Specific
+    OemSpecific,
+    /// A value unknown to this standard, check the raw value
+    None,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unit_test() {
+        let struct_type46 = vec![
+            // struct_type(46), length(0x09), handle(0x10)
+            0x2E, 0x09, 0x10, 0x00,
+            // string_property_id: (0x0001 - StringPropertyId::UefiDevicePath), string_property_value(1), parent_handle(0x0008)
+            0x01, 0x00, 0x01, 0x08, 0x00, //string_property_value: "Abcd"
+            b'A', b'b', b'c', b'd', 0x00, 0x00,
+        ];
+
+        let parts = UndefinedStruct::new(&struct_type46);
+        let test_struct = SMBiosStringProperty::new(&parts);
+
+        assert_eq!(
+            test_struct.string_property_id().unwrap().value,
+            StringPropertyId::UefiDevicePath
+        );
+
+        assert_eq!(test_struct.string_property_value().unwrap(), "Abcd");
+
+        assert_eq!(*test_struct.parent_handle().unwrap(), 8u16);
+    }
+}

--- a/src/structs/types/string_property.rs
+++ b/src/structs/types/string_property.rs
@@ -1,5 +1,5 @@
-use crate::core::Handle;
-use crate::{SMBiosStruct, UndefinedStruct};
+use crate::core::{Handle, SMBiosStringError, UndefinedStruct};
+use crate::SMBiosStruct;
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use std::fmt;
 use std::ops::Deref;
@@ -40,7 +40,7 @@ impl<'a> SMBiosStringProperty<'a> {
     }
 
     /// String Property Value
-    pub fn string_property_value(&self) -> Option<String> {
+    pub fn string_property_value(&self) -> Result<String, SMBiosStringError> {
         self.parts.get_field_string(0x06)
     }
 

--- a/src/structs/types/string_property.rs
+++ b/src/structs/types/string_property.rs
@@ -1,4 +1,4 @@
-use crate::core::{Handle, SMBiosStringError, UndefinedStruct};
+use crate::core::{strings::*, Handle, UndefinedStruct};
 use crate::SMBiosStruct;
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use std::fmt;
@@ -40,7 +40,7 @@ impl<'a> SMBiosStringProperty<'a> {
     }
 
     /// String Property Value
-    pub fn string_property_value(&self) -> Result<String, SMBiosStringError> {
+    pub fn string_property_value(&self) -> SMBiosString {
         self.parts.get_field_string(0x06)
     }
 
@@ -186,7 +186,7 @@ mod tests {
             StringPropertyId::UefiDevicePath
         );
 
-        assert_eq!(test_struct.string_property_value().unwrap(), "Abcd");
+        assert_eq!(test_struct.string_property_value().to_string(), "Abcd");
 
         assert_eq!(*test_struct.parent_handle().unwrap(), 8u16);
     }

--- a/src/structs/types/system_chassis_information.rs
+++ b/src/structs/types/system_chassis_information.rs
@@ -1,4 +1,4 @@
-use crate::core::{SMBiosStringError, UndefinedStruct};
+use crate::core::{strings::*, UndefinedStruct};
 use crate::{BoardTypeData, SMBiosStruct, SMBiosType};
 use serde::{ser::SerializeSeq, ser::SerializeStruct, Serialize, Serializer};
 use std::fmt;
@@ -35,7 +35,7 @@ impl<'a> SMBiosSystemChassisInformation<'a> {
     const CONTAINED_ELEMENTS_OFFSET: usize = 0x15usize;
 
     /// Manufacturer
-    pub fn manufacturer(&self) -> Result<String, SMBiosStringError> {
+    pub fn manufacturer(&self) -> SMBiosString {
         self.parts.get_field_string(0x04)
     }
 
@@ -52,17 +52,17 @@ impl<'a> SMBiosSystemChassisInformation<'a> {
     }
 
     /// Version
-    pub fn version(&self) -> Result<String, SMBiosStringError> {
+    pub fn version(&self) -> SMBiosString {
         self.parts.get_field_string(0x06)
     }
 
     /// Serial number
-    pub fn serial_number(&self) -> Result<String, SMBiosStringError> {
+    pub fn serial_number(&self) -> SMBiosString {
         self.parts.get_field_string(0x07)
     }
 
     /// Asset tag number
-    pub fn asset_tag_number(&self) -> Result<String, SMBiosStringError> {
+    pub fn asset_tag_number(&self) -> SMBiosString {
         self.parts.get_field_string(0x08)
     }
 
@@ -175,12 +175,12 @@ impl<'a> SMBiosSystemChassisInformation<'a> {
     /// SKU number
     ///
     /// Chassis or enclosure SKU number
-    pub fn sku_number(&self) -> Result<String, SMBiosStringError> {
+    pub fn sku_number(&self) -> SMBiosString {
         match self.contained_elements_size() {
             Some(size) => self
                 .parts
                 .get_field_string(Self::CONTAINED_ELEMENTS_OFFSET + size),
-            None => Err(SMBiosStringError::FieldOutOfBounds),
+            None => Err(SMBiosStringError::FieldOutOfBounds).into(),
         }
     }
 }
@@ -908,12 +908,15 @@ mod tests {
         let parts = UndefinedStruct::new(&struct_type3);
         let test_struct = SMBiosSystemChassisInformation::new(&parts);
 
-        assert_eq!(test_struct.manufacturer().unwrap(), "LENOVO".to_string());
+        assert_eq!(test_struct.manufacturer().to_string(), "LENOVO".to_string());
         assert_eq!(*test_struct.chassis_type().unwrap(), ChassisType::Desktop);
-        assert_eq!(test_struct.version().unwrap(), "None".to_string());
-        assert_eq!(test_struct.serial_number().unwrap(), "MJ06URDZ".to_string());
+        assert_eq!(test_struct.version().to_string(), "None".to_string());
         assert_eq!(
-            test_struct.asset_tag_number().unwrap(),
+            test_struct.serial_number().to_string(),
+            "MJ06URDZ".to_string()
+        );
+        assert_eq!(
+            test_struct.asset_tag_number().to_string(),
             "4089985".to_string()
         );
         assert_eq!(*test_struct.bootup_state().unwrap(), ChassisState::Safe);
@@ -954,7 +957,7 @@ mod tests {
             _ => panic!("expected baseboard type"),
         }
         assert_eq!(
-            test_struct.sku_number().unwrap(),
+            test_struct.sku_number().to_string(),
             "Default string".to_string()
         );
     }

--- a/src/structs/types/system_configuration_options.rs
+++ b/src/structs/types/system_configuration_options.rs
@@ -1,4 +1,4 @@
-use crate::{SMBiosStruct, Strings, UndefinedStruct};
+use crate::{SMBiosStringSet, SMBiosStruct, UndefinedStruct};
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use std::fmt;
 
@@ -36,7 +36,7 @@ impl<'a> SMBiosSystemConfigurationOptions<'a> {
     /// EXAMPLES:
     /// "JP2: 1-2 Cache Size is 256K, 2-3 Cache Size is 512K"
     /// "SW1-1: Close to Disable On Board Video"
-    pub fn configuration_strings(&self) -> &Strings {
+    pub fn configuration_strings(&self) -> &SMBiosStringSet {
         &self.parts.strings
     }
 }

--- a/src/structs/types/system_configuration_options.rs
+++ b/src/structs/types/system_configuration_options.rs
@@ -79,8 +79,13 @@ mod tests {
 
         assert_eq!(test_struct.count(), Some(1));
         assert_eq!(
-            test_struct.configuration_strings().into_iter().next(),
-            Some("scre++".to_string())
+            test_struct
+                .configuration_strings()
+                .into_iter()
+                .next()
+                .unwrap()
+                .unwrap(),
+            "scre++".to_string()
         );
     }
 }

--- a/src/structs/types/system_configuration_options.rs
+++ b/src/structs/types/system_configuration_options.rs
@@ -84,8 +84,8 @@ mod tests {
                 .into_iter()
                 .next()
                 .unwrap()
-                .unwrap(),
-            "scre++".to_string()
+                .ok(),
+            Some("scre++".to_string())
         );
     }
 }

--- a/src/structs/types/system_information.rs
+++ b/src/structs/types/system_information.rs
@@ -1,4 +1,5 @@
-use crate::{SMBiosStruct, UndefinedStruct};
+use crate::core::{SMBiosStringError, UndefinedStruct};
+use crate::SMBiosStruct;
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use std::{
     array::TryFromSliceError,
@@ -34,22 +35,22 @@ impl<'a> SMBiosStruct<'a> for SMBiosSystemInformation<'a> {
 
 impl<'a> SMBiosSystemInformation<'a> {
     /// Manufacturer
-    pub fn manufacturer(&self) -> Option<String> {
+    pub fn manufacturer(&self) -> Result<String, SMBiosStringError> {
         self.parts.get_field_string(0x04)
     }
 
     /// Product name
-    pub fn product_name(&self) -> Option<String> {
+    pub fn product_name(&self) -> Result<String, SMBiosStringError> {
         self.parts.get_field_string(0x05)
     }
 
     /// Version
-    pub fn version(&self) -> Option<String> {
+    pub fn version(&self) -> Result<String, SMBiosStringError> {
         self.parts.get_field_string(0x06)
     }
 
     /// Serial number
-    pub fn serial_number(&self) -> Option<String> {
+    pub fn serial_number(&self) -> Result<String, SMBiosStringError> {
         self.parts.get_field_string(0x07)
     }
 
@@ -80,7 +81,7 @@ impl<'a> SMBiosSystemInformation<'a> {
     /// given OEM, there are tens of unique
     /// processor, memory, hard drive, and optical
     /// drive configurations.
-    pub fn sku_number(&self) -> Option<String> {
+    pub fn sku_number(&self) -> Result<String, SMBiosStringError> {
         self.parts.get_field_string(0x19)
     }
 
@@ -95,7 +96,7 @@ impl<'a> SMBiosSystemInformation<'a> {
     /// different configurations and pricing points.
     /// Computers in the same family often have
     /// similar branding and cosmetic features.
-    pub fn family(&self) -> Option<String> {
+    pub fn family(&self) -> Result<String, SMBiosStringError> {
         self.parts.get_field_string(0x1A)
     }
 }
@@ -378,10 +379,16 @@ mod tests {
         let parts = UndefinedStruct::new(&struct_type1);
         let test_struct = SMBiosSystemInformation::new(&parts);
 
-        assert_eq!(test_struct.manufacturer(), Some("LENOVO".to_string()));
-        assert_eq!(test_struct.product_name(), Some("30BFS07500".to_string()));
-        assert_eq!(test_struct.version(), Some("ThinkStation P520".to_string()));
-        assert_eq!(test_struct.serial_number(), Some("MN06PQRS".to_string()));
+        assert_eq!(test_struct.manufacturer().unwrap(), "LENOVO".to_string());
+        assert_eq!(
+            test_struct.product_name().unwrap(),
+            "30BFS07500".to_string()
+        );
+        assert_eq!(
+            test_struct.version().unwrap(),
+            "ThinkStation P520".to_string()
+        );
+        assert_eq!(test_struct.serial_number().unwrap(), "MN06PQRS".to_string());
         assert_eq!(
             format!("{:?}", test_struct.uuid()),
             "Some(Uuid(3e2501d2-e648-e811-bad3-7020840f9d47))".to_string()
@@ -391,9 +398,12 @@ mod tests {
             SystemWakeUpType::PowerSwitch
         );
         assert_eq!(
-            test_struct.sku_number(),
-            Some("LENOVO_MT_30BF_BU_Think_FM_ThinkStation P520".to_string())
+            test_struct.sku_number().unwrap(),
+            "LENOVO_MT_30BF_BU_Think_FM_ThinkStation P520".to_string()
         );
-        assert_eq!(test_struct.family(), Some("ThinkStation P520".to_string()));
+        assert_eq!(
+            test_struct.family().unwrap(),
+            "ThinkStation P520".to_string()
+        );
     }
 }

--- a/src/structs/types/system_information.rs
+++ b/src/structs/types/system_information.rs
@@ -1,4 +1,4 @@
-use crate::core::{SMBiosStringError, UndefinedStruct};
+use crate::core::{strings::*, UndefinedStruct};
 use crate::SMBiosStruct;
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use std::{
@@ -35,22 +35,22 @@ impl<'a> SMBiosStruct<'a> for SMBiosSystemInformation<'a> {
 
 impl<'a> SMBiosSystemInformation<'a> {
     /// Manufacturer
-    pub fn manufacturer(&self) -> Result<String, SMBiosStringError> {
+    pub fn manufacturer(&self) -> SMBiosString {
         self.parts.get_field_string(0x04)
     }
 
     /// Product name
-    pub fn product_name(&self) -> Result<String, SMBiosStringError> {
+    pub fn product_name(&self) -> SMBiosString {
         self.parts.get_field_string(0x05)
     }
 
     /// Version
-    pub fn version(&self) -> Result<String, SMBiosStringError> {
+    pub fn version(&self) -> SMBiosString {
         self.parts.get_field_string(0x06)
     }
 
     /// Serial number
-    pub fn serial_number(&self) -> Result<String, SMBiosStringError> {
+    pub fn serial_number(&self) -> SMBiosString {
         self.parts.get_field_string(0x07)
     }
 
@@ -81,7 +81,7 @@ impl<'a> SMBiosSystemInformation<'a> {
     /// given OEM, there are tens of unique
     /// processor, memory, hard drive, and optical
     /// drive configurations.
-    pub fn sku_number(&self) -> Result<String, SMBiosStringError> {
+    pub fn sku_number(&self) -> SMBiosString {
         self.parts.get_field_string(0x19)
     }
 
@@ -96,7 +96,7 @@ impl<'a> SMBiosSystemInformation<'a> {
     /// different configurations and pricing points.
     /// Computers in the same family often have
     /// similar branding and cosmetic features.
-    pub fn family(&self) -> Result<String, SMBiosStringError> {
+    pub fn family(&self) -> SMBiosString {
         self.parts.get_field_string(0x1A)
     }
 }
@@ -379,16 +379,19 @@ mod tests {
         let parts = UndefinedStruct::new(&struct_type1);
         let test_struct = SMBiosSystemInformation::new(&parts);
 
-        assert_eq!(test_struct.manufacturer().unwrap(), "LENOVO".to_string());
+        assert_eq!(test_struct.manufacturer().to_string(), "LENOVO".to_string());
         assert_eq!(
-            test_struct.product_name().unwrap(),
+            test_struct.product_name().to_string(),
             "30BFS07500".to_string()
         );
         assert_eq!(
-            test_struct.version().unwrap(),
+            test_struct.version().to_string(),
             "ThinkStation P520".to_string()
         );
-        assert_eq!(test_struct.serial_number().unwrap(), "MN06PQRS".to_string());
+        assert_eq!(
+            test_struct.serial_number().to_string(),
+            "MN06PQRS".to_string()
+        );
         assert_eq!(
             format!("{:?}", test_struct.uuid()),
             "Some(Uuid(3e2501d2-e648-e811-bad3-7020840f9d47))".to_string()
@@ -398,11 +401,11 @@ mod tests {
             SystemWakeUpType::PowerSwitch
         );
         assert_eq!(
-            test_struct.sku_number().unwrap(),
+            test_struct.sku_number().to_string(),
             "LENOVO_MT_30BF_BU_Think_FM_ThinkStation P520".to_string()
         );
         assert_eq!(
-            test_struct.family().unwrap(),
+            test_struct.family().to_string(),
             "ThinkStation P520".to_string()
         );
     }

--- a/src/structs/types/system_power_supply.rs
+++ b/src/structs/types/system_power_supply.rs
@@ -1,4 +1,5 @@
-use crate::{Handle, SMBiosStruct, UndefinedStruct};
+use crate::core::{Handle, SMBiosStringError, UndefinedStruct};
+use crate::SMBiosStruct;
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use std::fmt;
 
@@ -51,7 +52,7 @@ impl<'a> SMBiosSystemPowerSupply<'a> {
     ///
     /// EXAMPLES: "in the back, on the left-hand side" or
     /// "Left Supply Bay"
-    pub fn location(&self) -> Option<String> {
+    pub fn location(&self) -> Result<String, SMBiosStringError> {
         self.parts.get_field_string(0x05)
     }
 
@@ -60,33 +61,33 @@ impl<'a> SMBiosSystemPowerSupply<'a> {
     /// Number of the string that names the power supply device
     ///
     /// EXAMPLE: "DR-36"
-    pub fn device_name(&self) -> Option<String> {
+    pub fn device_name(&self) -> Result<String, SMBiosStringError> {
         self.parts.get_field_string(0x06)
     }
 
     /// Manufacturer
     ///
     /// Names the company that manufactured the supply
-    pub fn manufacturer(&self) -> Option<String> {
+    pub fn manufacturer(&self) -> Result<String, SMBiosStringError> {
         self.parts.get_field_string(0x07)
     }
 
     /// Serial number
     ///
     /// The serial number for the power supply
-    pub fn serial_number(&self) -> Option<String> {
+    pub fn serial_number(&self) -> Result<String, SMBiosStringError> {
         self.parts.get_field_string(0x08)
     }
 
     /// Asset tag number
-    pub fn asset_tag_number(&self) -> Option<String> {
+    pub fn asset_tag_number(&self) -> Result<String, SMBiosStringError> {
         self.parts.get_field_string(0x09)
     }
 
     /// Model part number
     ///
     /// The OEM part order number
-    pub fn model_part_number(&self) -> Option<String> {
+    pub fn model_part_number(&self) -> Result<String, SMBiosStringError> {
         self.parts.get_field_string(0x0A)
     }
 
@@ -95,7 +96,7 @@ impl<'a> SMBiosSystemPowerSupply<'a> {
     /// Power supply revision string
     ///
     /// EXAMPLE: "2.30"
-    pub fn revision_level(&self) -> Option<String> {
+    pub fn revision_level(&self) -> Result<String, SMBiosStringError> {
         self.parts.get_field_string(0x0B)
     }
 
@@ -454,32 +455,32 @@ mod tests {
         println!("{:?}", test_struct);
         assert_eq!(test_struct.power_unit_group(), Some(1));
         assert_eq!(
-            test_struct.location(),
-            Some("To Be Filled By O.E.M.".to_string())
+            test_struct.location().unwrap(),
+            "To Be Filled By O.E.M.".to_string()
         );
         assert_eq!(
-            test_struct.device_name(),
-            Some("To Be Filled By O.E.M.".to_string())
+            test_struct.device_name().unwrap(),
+            "To Be Filled By O.E.M.".to_string()
         );
         assert_eq!(
-            test_struct.manufacturer(),
-            Some("To Be Filled By O.E.M.".to_string())
+            test_struct.manufacturer().unwrap(),
+            "To Be Filled By O.E.M.".to_string()
         );
         assert_eq!(
-            test_struct.serial_number(),
-            Some("To Be Filled By O.E.M.".to_string())
+            test_struct.serial_number().unwrap(),
+            "To Be Filled By O.E.M.".to_string()
         );
         assert_eq!(
-            test_struct.asset_tag_number(),
-            Some("To Be Filled By O.E.M.".to_string())
+            test_struct.asset_tag_number().unwrap(),
+            "To Be Filled By O.E.M.".to_string()
         );
         assert_eq!(
-            test_struct.model_part_number(),
-            Some("To Be Filled By O.E.M.".to_string())
+            test_struct.model_part_number().unwrap(),
+            "To Be Filled By O.E.M.".to_string()
         );
         assert_eq!(
-            test_struct.revision_level(),
-            Some("To Be Filled By O.E.M.".to_string())
+            test_struct.revision_level().unwrap(),
+            "To Be Filled By O.E.M.".to_string()
         );
         assert_eq!(
             test_struct.max_power_capacity(),

--- a/src/structs/types/system_power_supply.rs
+++ b/src/structs/types/system_power_supply.rs
@@ -1,4 +1,4 @@
-use crate::core::{Handle, SMBiosStringError, UndefinedStruct};
+use crate::core::{strings::*, Handle, UndefinedStruct};
 use crate::SMBiosStruct;
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use std::fmt;
@@ -52,7 +52,7 @@ impl<'a> SMBiosSystemPowerSupply<'a> {
     ///
     /// EXAMPLES: "in the back, on the left-hand side" or
     /// "Left Supply Bay"
-    pub fn location(&self) -> Result<String, SMBiosStringError> {
+    pub fn location(&self) -> SMBiosString {
         self.parts.get_field_string(0x05)
     }
 
@@ -61,33 +61,33 @@ impl<'a> SMBiosSystemPowerSupply<'a> {
     /// Number of the string that names the power supply device
     ///
     /// EXAMPLE: "DR-36"
-    pub fn device_name(&self) -> Result<String, SMBiosStringError> {
+    pub fn device_name(&self) -> SMBiosString {
         self.parts.get_field_string(0x06)
     }
 
     /// Manufacturer
     ///
     /// Names the company that manufactured the supply
-    pub fn manufacturer(&self) -> Result<String, SMBiosStringError> {
+    pub fn manufacturer(&self) -> SMBiosString {
         self.parts.get_field_string(0x07)
     }
 
     /// Serial number
     ///
     /// The serial number for the power supply
-    pub fn serial_number(&self) -> Result<String, SMBiosStringError> {
+    pub fn serial_number(&self) -> SMBiosString {
         self.parts.get_field_string(0x08)
     }
 
     /// Asset tag number
-    pub fn asset_tag_number(&self) -> Result<String, SMBiosStringError> {
+    pub fn asset_tag_number(&self) -> SMBiosString {
         self.parts.get_field_string(0x09)
     }
 
     /// Model part number
     ///
     /// The OEM part order number
-    pub fn model_part_number(&self) -> Result<String, SMBiosStringError> {
+    pub fn model_part_number(&self) -> SMBiosString {
         self.parts.get_field_string(0x0A)
     }
 
@@ -96,7 +96,7 @@ impl<'a> SMBiosSystemPowerSupply<'a> {
     /// Power supply revision string
     ///
     /// EXAMPLE: "2.30"
-    pub fn revision_level(&self) -> Result<String, SMBiosStringError> {
+    pub fn revision_level(&self) -> SMBiosString {
         self.parts.get_field_string(0x0B)
     }
 
@@ -455,31 +455,31 @@ mod tests {
         println!("{:?}", test_struct);
         assert_eq!(test_struct.power_unit_group(), Some(1));
         assert_eq!(
-            test_struct.location().unwrap(),
+            test_struct.location().to_string(),
             "To Be Filled By O.E.M.".to_string()
         );
         assert_eq!(
-            test_struct.device_name().unwrap(),
+            test_struct.device_name().to_string(),
             "To Be Filled By O.E.M.".to_string()
         );
         assert_eq!(
-            test_struct.manufacturer().unwrap(),
+            test_struct.manufacturer().to_string(),
             "To Be Filled By O.E.M.".to_string()
         );
         assert_eq!(
-            test_struct.serial_number().unwrap(),
+            test_struct.serial_number().to_string(),
             "To Be Filled By O.E.M.".to_string()
         );
         assert_eq!(
-            test_struct.asset_tag_number().unwrap(),
+            test_struct.asset_tag_number().to_string(),
             "To Be Filled By O.E.M.".to_string()
         );
         assert_eq!(
-            test_struct.model_part_number().unwrap(),
+            test_struct.model_part_number().to_string(),
             "To Be Filled By O.E.M.".to_string()
         );
         assert_eq!(
-            test_struct.revision_level().unwrap(),
+            test_struct.revision_level().to_string(),
             "To Be Filled By O.E.M.".to_string()
         );
         assert_eq!(

--- a/src/structs/types/system_slot.rs
+++ b/src/structs/types/system_slot.rs
@@ -1,4 +1,5 @@
-use crate::{SMBiosStruct, UndefinedStruct};
+use crate::core::{SMBiosStringError, UndefinedStruct};
+use crate::SMBiosStruct;
 use serde::{ser::SerializeSeq, ser::SerializeStruct, Serialize, Serializer};
 use std::{convert::TryInto, fmt, ops::Deref};
 
@@ -28,7 +29,7 @@ impl<'a> SMBiosStruct<'a> for SMBiosSystemSlot<'a> {
 
 impl<'a> SMBiosSystemSlot<'a> {
     /// Slot Designation
-    pub fn slot_designation(&self) -> Option<String> {
+    pub fn slot_designation(&self) -> Result<String, SMBiosStringError> {
         self.parts.get_field_string(0x04)
     }
 
@@ -1385,7 +1386,7 @@ mod tests {
         let parts = UndefinedStruct::new(&struct_type9);
         let test_struct = SMBiosSystemSlot::new(&parts);
 
-        assert_eq!(test_struct.slot_designation(), Some("J6B2".to_string()));
+        assert_eq!(test_struct.slot_designation().unwrap(), "J6B2".to_string());
 
         assert_eq!(
             *test_struct.system_slot_type().unwrap(),

--- a/src/structs/types/system_slot.rs
+++ b/src/structs/types/system_slot.rs
@@ -124,7 +124,7 @@ impl<'a> SMBiosSystemSlot<'a> {
     /// Slot Information
     pub fn slot_information(&self) -> Option<u8> {
         self.peer_group_size()
-            .and_then(|size| self.parts.get_field_byte(size + 0x13)) // TODO: watch for an errata, 0x13 is 0x14 in the 3.4.0 spec.
+            .and_then(|size| self.parts.get_field_byte(size + 0x13))
     }
 
     /// Slot Physical Width
@@ -157,6 +157,19 @@ impl<'a> SMBiosSystemSlot<'a> {
     pub fn slot_pitch(&self) -> Option<u16> {
         self.peer_group_size()
             .and_then(|size| self.parts.get_field_word(size + 0x15))
+    }
+
+    /// Slot Height
+    ///
+    /// This field indicates the maximum supported card height for the slot.
+    ///
+    /// Available in version 3.5.0 and later.
+    pub fn slot_height(&self) -> Option<SlotHeightData> {
+        self.peer_group_size().and_then(|size| {
+            self.parts
+                .get_field_byte(size + 0x17)
+                .map(|raw| SlotHeightData::from(raw))
+        })
     }
 }
 
@@ -648,6 +661,81 @@ pub enum SlotWidth {
     X16,
     /// 32x or x32
     X32,
+    /// A value unknown to this standard, check the raw value
+    None,
+}
+
+/// # Slot Height Data
+pub struct SlotHeightData {
+    /// Raw value
+    ///
+    /// _raw_ is most useful when _value_ is None.
+    /// This is most likely to occur when the standard was updated but
+    /// this library code has not been updated to match the current
+    /// standard.
+    pub raw: u8,
+    /// The contained [SlotHeight] value
+    pub value: SlotHeight,
+}
+
+impl Deref for SlotHeightData {
+    type Target = SlotHeight;
+
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
+impl From<u8> for SlotHeightData {
+    fn from(raw: u8) -> Self {
+        SlotHeightData {
+            value: match raw {
+                0x00 => SlotHeight::NotApplicable,
+                0x01 => SlotHeight::Other,
+                0x02 => SlotHeight::Unknown,
+                0x03 => SlotHeight::FullHeight,
+                0x04 => SlotHeight::LowProfile,
+                _ => SlotHeight::None,
+            },
+            raw,
+        }
+    }
+}
+
+impl fmt::Debug for SlotHeightData {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.debug_struct(std::any::type_name::<SlotHeightData>())
+            .field("raw", &self.raw)
+            .field("value", &self.value)
+            .finish()
+    }
+}
+
+impl Serialize for SlotHeightData {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut state = serializer.serialize_struct("SlotHeightData", 2)?;
+        state.serialize_field("raw", &self.raw)?;
+        state.serialize_field("value", &self.value)?;
+        state.end()
+    }
+}
+
+/// # Slot Height
+#[derive(Serialize, Debug, PartialEq, Eq)]
+pub enum SlotHeight {
+    /// Not Applicable
+    NotApplicable,
+    /// Other
+    Other,
+    /// Unknown
+    Unknown,
+    /// Full Height
+    FullHeight,
+    /// Low-profile
+    LowProfile,
     /// A value unknown to this standard, check the raw value
     None,
 }

--- a/src/structs/types/system_slot.rs
+++ b/src/structs/types/system_slot.rs
@@ -1,4 +1,4 @@
-use crate::core::{SMBiosStringError, UndefinedStruct};
+use crate::core::{strings::*, UndefinedStruct};
 use crate::SMBiosStruct;
 use serde::{ser::SerializeSeq, ser::SerializeStruct, Serialize, Serializer};
 use std::{convert::TryInto, fmt, ops::Deref};
@@ -29,7 +29,7 @@ impl<'a> SMBiosStruct<'a> for SMBiosSystemSlot<'a> {
 
 impl<'a> SMBiosSystemSlot<'a> {
     /// Slot Designation
-    pub fn slot_designation(&self) -> Result<String, SMBiosStringError> {
+    pub fn slot_designation(&self) -> SMBiosString {
         self.parts.get_field_string(0x04)
     }
 
@@ -1386,7 +1386,10 @@ mod tests {
         let parts = UndefinedStruct::new(&struct_type9);
         let test_struct = SMBiosSystemSlot::new(&parts);
 
-        assert_eq!(test_struct.slot_designation().unwrap(), "J6B2".to_string());
+        assert_eq!(
+            test_struct.slot_designation().to_string(),
+            "J6B2".to_string()
+        );
 
         assert_eq!(
             *test_struct.system_slot_type().unwrap(),

--- a/src/structs/types/system_slot.rs
+++ b/src/structs/types/system_slot.rs
@@ -6,6 +6,10 @@ use std::{convert::TryInto, fmt, ops::Deref};
 ///
 /// The information in this structure defines the attributes of a system slot. One
 /// structure is provided for each slot in the system.
+///
+/// Compliant with:
+/// DMTF SMBIOS Reference Specification 3.5.0 (DSP0134)
+/// Document Date: 2021-09-15
 pub struct SMBiosSystemSlot<'a> {
     parts: &'a UndefinedStruct,
 }

--- a/src/structs/types/temperature_probe.rs
+++ b/src/structs/types/temperature_probe.rs
@@ -1,4 +1,5 @@
-use crate::{SMBiosStruct, UndefinedStruct};
+use crate::core::{SMBiosStringError, UndefinedStruct};
+use crate::SMBiosStruct;
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use std::fmt;
 
@@ -28,7 +29,7 @@ impl<'a> SMBiosTemperatureProbe<'a> {
     /// Description
     ///
     /// additional descriptive information about the probe or its location
-    pub fn description(&self) -> Option<String> {
+    pub fn description(&self) -> Result<String, SMBiosStringError> {
         self.parts.get_field_string(0x04)
     }
 
@@ -365,7 +366,7 @@ mod tests {
         let parts = UndefinedStruct::new(&struct_type28);
         let test_struct = SMBiosTemperatureProbe::new(&parts);
 
-        assert_eq!(test_struct.description(), Some("LM78A".to_string()));
+        assert_eq!(test_struct.description().unwrap(), "LM78A".to_string());
         assert_eq!(
             test_struct.location_and_status(),
             Some(TemperatureProbeLocationAndStatus::from(103))

--- a/src/structs/types/temperature_probe.rs
+++ b/src/structs/types/temperature_probe.rs
@@ -1,4 +1,4 @@
-use crate::core::{SMBiosStringError, UndefinedStruct};
+use crate::core::{strings::*, UndefinedStruct};
 use crate::SMBiosStruct;
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use std::fmt;
@@ -29,7 +29,7 @@ impl<'a> SMBiosTemperatureProbe<'a> {
     /// Description
     ///
     /// additional descriptive information about the probe or its location
-    pub fn description(&self) -> Result<String, SMBiosStringError> {
+    pub fn description(&self) -> SMBiosString {
         self.parts.get_field_string(0x04)
     }
 
@@ -366,7 +366,7 @@ mod tests {
         let parts = UndefinedStruct::new(&struct_type28);
         let test_struct = SMBiosTemperatureProbe::new(&parts);
 
-        assert_eq!(test_struct.description().unwrap(), "LM78A".to_string());
+        assert_eq!(test_struct.description().to_string(), "LM78A".to_string());
         assert_eq!(
             test_struct.location_and_status(),
             Some(TemperatureProbeLocationAndStatus::from(103))

--- a/src/structs/types/tpm_device.rs
+++ b/src/structs/types/tpm_device.rs
@@ -1,4 +1,4 @@
-use crate::core::{SMBiosStringError, UndefinedStruct};
+use crate::core::{strings::*, UndefinedStruct};
 use crate::SMBiosStruct;
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use std::{array::TryFromSliceError, convert::TryFrom, fmt, ops::Deref};
@@ -84,7 +84,7 @@ impl<'a> SMBiosTpmDevice<'a> {
     /// Description
     ///
     /// Descriptive information of the TPM device.
-    pub fn description(&self) -> Result<String, SMBiosStringError> {
+    pub fn description(&self) -> SMBiosString {
         self.parts.get_field_string(0x12)
     }
 
@@ -314,7 +314,10 @@ mod tests {
         assert_eq!(test_struct.minor_spec_version(), Some(0));
         assert_eq!(test_struct.firmware_version_1(), Some(327742));
         assert_eq!(test_struct.firmware_version_2(), Some(800256));
-        assert_eq!(test_struct.description().unwrap(), "INFINEON".to_string());
+        assert_eq!(
+            test_struct.description().to_string(),
+            "INFINEON".to_string()
+        );
         assert_eq!(
             test_struct.characteristics(),
             Some(TpmDeviceCharacteristics::from(16))

--- a/src/structs/types/tpm_device.rs
+++ b/src/structs/types/tpm_device.rs
@@ -1,4 +1,5 @@
-use crate::{SMBiosStruct, UndefinedStruct};
+use crate::core::{SMBiosStringError, UndefinedStruct};
+use crate::SMBiosStruct;
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use std::{array::TryFromSliceError, convert::TryFrom, fmt, ops::Deref};
 
@@ -83,7 +84,7 @@ impl<'a> SMBiosTpmDevice<'a> {
     /// Description
     ///
     /// Descriptive information of the TPM device.
-    pub fn description(&self) -> Option<String> {
+    pub fn description(&self) -> Result<String, SMBiosStringError> {
         self.parts.get_field_string(0x12)
     }
 
@@ -313,7 +314,7 @@ mod tests {
         assert_eq!(test_struct.minor_spec_version(), Some(0));
         assert_eq!(test_struct.firmware_version_1(), Some(327742));
         assert_eq!(test_struct.firmware_version_2(), Some(800256));
-        assert_eq!(test_struct.description(), Some("INFINEON".to_string()));
+        assert_eq!(test_struct.description().unwrap(), "INFINEON".to_string());
         assert_eq!(
             test_struct.characteristics(),
             Some(TpmDeviceCharacteristics::from(16))

--- a/src/structs/types/voltage_probe.rs
+++ b/src/structs/types/voltage_probe.rs
@@ -1,4 +1,4 @@
-use crate::core::{SMBiosStringError, UndefinedStruct};
+use crate::core::{strings::*, UndefinedStruct};
 use crate::SMBiosStruct;
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use std::fmt;
@@ -29,7 +29,7 @@ impl<'a> SMBiosVoltageProbe<'a> {
     /// Description
     ///
     /// Additional descriptive information about the probe or its location
-    pub fn description(&self) -> Result<String, SMBiosStringError> {
+    pub fn description(&self) -> SMBiosString {
         self.parts.get_field_string(0x04)
     }
 
@@ -346,7 +346,7 @@ mod tests {
         let parts = UndefinedStruct::new(&struct_type26);
         let test_struct = SMBiosVoltageProbe::new(&parts);
 
-        assert_eq!(test_struct.description().unwrap(), "LM78A".to_string());
+        assert_eq!(test_struct.description().to_string(), "LM78A".to_string());
         assert_eq!(
             test_struct.location_and_status(),
             Some(VoltageProbeLocationAndStatus::from(103))

--- a/src/structs/types/voltage_probe.rs
+++ b/src/structs/types/voltage_probe.rs
@@ -1,4 +1,5 @@
-use crate::{SMBiosStruct, UndefinedStruct};
+use crate::core::{SMBiosStringError, UndefinedStruct};
+use crate::SMBiosStruct;
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use std::fmt;
 
@@ -28,7 +29,7 @@ impl<'a> SMBiosVoltageProbe<'a> {
     /// Description
     ///
     /// Additional descriptive information about the probe or its location
-    pub fn description(&self) -> Option<String> {
+    pub fn description(&self) -> Result<String, SMBiosStringError> {
         self.parts.get_field_string(0x04)
     }
 
@@ -345,7 +346,7 @@ mod tests {
         let parts = UndefinedStruct::new(&struct_type26);
         let test_struct = SMBiosVoltageProbe::new(&parts);
 
-        assert_eq!(test_struct.description(), Some("LM78A".to_string()));
+        assert_eq!(test_struct.description().unwrap(), "LM78A".to_string());
         assert_eq!(
             test_struct.location_and_status(),
             Some(VoltageProbeLocationAndStatus::from(103))


### PR DESCRIPTION
3.5.0
The following changes were made to version 3.4.0 of the document to produce this
version:

Normative references (section 2): various updates
Terms and Definitions (section 3):
– SMBIOSCR00206: Clarification on unknown/other
Table Convention (section 5.2):
– SMBIOSCR00207: Log Change Token is volatile
Structure Header Format (section 6.1.2):
– SMBIOSCR00213: Clarified invalid reference handle value
Text Strings (section 6.1.3):
– SMBIOSCR00212: Specified that string encoding is UTF-8
BIOS Information (Type 0):
– SMBIOSCR00209: Added support for manufacturing mode
– SMBIOSCR00210: Updated the definition of BIOS Starting Address Segment
for UEFI systems
Processor Information (Type 4):
– SMBIOSCR00205: Added processor socket (LGA4677)
System Slots (Type 9):
– SMBIOSCR00202: Added support for slot height
– SMBIOSCR00203: Errata: correct offsets
Built-in Pointing Device (Type 21):
– SMBIOSCR00200: Added support for new Pointing Device interfaces
Onboard Devices Extended Information (Type 41):
– SMBIOSCR00201: Added support for new Onboard Device Types
– SMBIOSCR00204: Added note on how to describe multi-function devices
Firmware Inventory Information (Type 45, new):
– SMBIOSCR00208: Added structure type for Firmware Inventory Information
String Property (Type 46, new):
– SMBIOSCR00211: Added structure for string properties