### PR TITLE
Output UUIDs to lower case

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ fn retrieve_system_uuid() {
 Output:
 ```
 running 1 test
-System Information UUID == Uuid(4EE6523F-D56A-F3EA-8E2A-891CF96286EA)
+System Information UUID == Uuid(4ee6523f-d56a-f3ea-8e2a-891cf96286ea)
 test retrieve_system_uuid ... ok
 ```
 

--- a/src/structs/types/system_information.rs
+++ b/src/structs/types/system_information.rs
@@ -384,7 +384,7 @@ mod tests {
         assert_eq!(test_struct.serial_number(), Some("MN06PQRS".to_string()));
         assert_eq!(
             format!("{:?}", test_struct.uuid()),
-            "Some(Uuid(3E2501D2-E648-E811-BAD3-7020840F9D47))".to_string()
+            "Some(Uuid(3e2501d2-e648-e811-bad3-7020840f9d47))".to_string()
         );
         assert_eq!(
             *test_struct.wakeup_type().unwrap(),

--- a/src/structs/types/system_information.rs
+++ b/src/structs/types/system_information.rs
@@ -243,7 +243,7 @@ impl fmt::Display for SystemUuid {
         )?;
 
         self.node().iter().fold(Ok(()), |result, node_byte| {
-            result.and_then(|_| write!(f, "{:02X}", node_byte))
+            result.and_then(|_| write!(f, "{:02x}", node_byte))
         })
     }
 }

--- a/src/structs/types/system_information.rs
+++ b/src/structs/types/system_information.rs
@@ -224,11 +224,17 @@ impl<'a> From<&'a [u8; 0x10]> for SystemUuid {
 impl fmt::Display for SystemUuid {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // Example output:
-        // "00360FE7-D4D5-11E5-9C43-BC0000F00000"
+        // "00360fe7-d4d5-11e5-9c43-bc0000f00000"
         // <TimeLow>-<TimeMid>-<TimeHiAndVersion>-<ClockSeqHiAndReserved><ClockSeqLow>-<Node[6]>
+
+        // Format is described in RFC4122, but the actual field contents are opaque and not
+        // significant to the SMBIOS specification, which is only concerned with the byte order.
+        // http://www.ietf.org/rfc/rfc4122.txt
+        // RFC4122: The hexadecimal values "a" through "f" are output as
+        // lower case characters and are case insensitive on input.
         write!(
             f,
-            "{:08X}-{:04X}-{:04X}-{:02X}{:02X}-",
+            "{:08x}-{:04x}-{:04x}-{:02x}{:02x}-",
             self.time_low(),
             self.time_mid(),
             self.time_high_and_version(),


### PR DESCRIPTION
To comply with RFC4122, we should output as lowercase.