### PR TITLE
fix: `use-after-free` in `try_load_macos_table` leading to segfault

### DIFF
--- a/src/macos/platform.rs
+++ b/src/macos/platform.rs
@@ -102,16 +102,12 @@ fn try_load_macos_table() -> Result<Vec<u8>, Error> {
             return Err(Error::new(ErrorKind::NotFound, "SMBIOS is unreachable"));
         }
 
-        if !data_ref.is_null() {
-            CFRelease(data_ref.as_void_ptr());
-        }
-
         let data_ptr = CFDataGetBytePtr(data_ref);
         let data_length = CFDataGetLength(data_ref);
-        let mut table: Vec<u8> = Vec::with_capacity(data_length as usize);
 
-        std::ptr::copy(data_ptr, table.as_mut_ptr(), data_length as usize);
-        table.set_len(data_length as usize);
+        let table = std::slice::from_raw_parts(data_ptr, data_length as usize).to_vec();
+
+        CFRelease(data_ref.as_void_ptr());
 
         Ok(table)
     }

--- a/src/macos/platform.rs
+++ b/src/macos/platform.rs
@@ -69,16 +69,12 @@ fn try_load_macos_entry_point() -> Result<SMBiosEntryPoint32, Error> {
             ));
         }
 
-        if !data_ref.is_null() {
-            CFRelease(data_ref.as_void_ptr());
-        }
-
         let data_ptr = CFDataGetBytePtr(data_ref);
         let data_length = CFDataGetLength(data_ref);
-        let mut entry_point = Vec::with_capacity(data_length as usize);
 
-        std::ptr::copy(data_ptr, entry_point.as_mut_ptr(), data_length as usize);
-        entry_point.set_len(data_length as usize);
+        let entry_point = std::slice::from_raw_parts(data_ptr, data_length as usize).to_vec();
+
+        CFRelease(data_ref.as_void_ptr());
 
         SMBiosEntryPoint32::try_from(entry_point)
     }


### PR DESCRIPTION
`CFRelease` is called on `data_ref` in line 105 and then immediately used in line 109, 110