### PR TITLE
Use license and relax dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "smbios-lib"
 version = "0.9.2"
 authors = ["Jeffrey R. Gerber <jeffreygerber@gmail.com>", "Ante Čulo <dante2711@gmail.com>", "Juan Zuluaga <juzuluag@hotmail.com>"]
-license-file = "LICENSE"
+license = "MIT"
 edition = "2018"
 description = "SMBIOS Library"
 homepage = "https://github.com/jrgerber/smbios-lib"
@@ -24,7 +24,7 @@ path = "src/main.rs"
 [dependencies]
 getopts = "0.2.21"
 serde = { version = "1", features = ["derive"] }
-serde_json = "~1.0"
+serde_json = "1"
 
 [target.'cfg(windows)'.dependencies]
 libc = "0.2"


### PR DESCRIPTION
When packaging this crate for fedora, I found some warnings and I decided to provide a PR to fix them. This PR fixes the warnings from ` rust2rpm -s smbios-lib`. These fixes can also be done when patching `Cargo.toml` during the RPM generation in case maintainer does not agree.  